### PR TITLE
Script for importing blog posts from lizards.o.o

### DIFF
--- a/jekyll/.gitignore
+++ b/jekyll/.gitignore
@@ -1,0 +1,6 @@
+/.bundle
+/.byebug_history
+/.vendor
+/_posts
+/images
+

--- a/jekyll/Gemfile
+++ b/jekyll/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gem "jekyll-import"
+gem "kramdown"
+# gem "byebug"

--- a/jekyll/Gemfile.lock
+++ b/jekyll/Gemfile.lock
@@ -1,0 +1,56 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    colorator (1.1.0)
+    fastercsv (1.5.5)
+    ffi (1.9.14)
+    forwardable-extended (2.6.0)
+    jekyll (3.3.1)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-import (0.12.0)
+      fastercsv
+      jekyll (>= 1.4)
+      nokogiri
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.13.1)
+    liquid (3.0.6)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    mini_portile2 (2.1.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (2.0.4)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.4.22)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll-import
+  kramdown
+
+BUNDLED WITH
+   1.10.6

--- a/jekyll/README.md
+++ b/jekyll/README.md
@@ -1,0 +1,38 @@
+
+# The Blog Posts Importer
+
+This is an importer script for importing the YaST posts from https://lizards.opensuse.org/
+into the blog based on Jekyll which uses the Markdown format.
+
+# Pre-requisites
+
+- Ruby
+- Bundler (`zypper in 'rubygem(bundler)'`)
+
+# The Process
+
+The convertor uses the patched RSS feed importer (http://import.jekyllrb.com/docs/rss/).
+The posts are extracted from the RSS feed.
+
+However, the feed contains only few latest posts, fortunately the older feeds
+can be found in the Web archive at http://web.archive.org/web/*/https://lizards.opensuse.org/feed/
+But some posts are missing in the feeds as the Web Archiver archived
+the feed only few times in the history, therefore the missing posts are
+imported directly from a saved lizards.o.o. HTML page.
+
+All needed posts to import are stored locally in the `feed*.xml` and
+`page2.html` files.
+
+# Starting the Import
+
+```
+bundle install --path .vendor/bundle
+bundle exec ruby ./lizards_importer.rb
+```
+
+The converted posts are saved into `_posts` directory, the downloaded images
+to `images` directory.
+
+The imported posts still need some manual fine tuning (enable syntax
+highlighting, fix not converted HTML tags, fix the links pointing to
+lizards.o.o., ...).

--- a/jekyll/feed.xml
+++ b/jekyll/feed.xml
@@ -1,0 +1,849 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	>
+
+<channel>
+	<title>openSUSE Lizards</title>
+	<atom:link href="https://lizards.opensuse.org/feed/" rel="self" type="application/rss+xml" />
+	<link>https://lizards.opensuse.org</link>
+	<description>Blogs and Ramblings of the openSUSE Members</description>
+	<lastBuildDate>Fri, 02 Dec 2016 14:13:07 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>hourly</sy:updatePeriod>
+	<sy:updateFrequency>1</sy:updateFrequency>
+	<generator>https://wordpress.org/?v=4.6.1</generator>
+	<item>
+		<title>Highlights of YaST development sprint 28</title>
+		<link>https://lizards.opensuse.org/2016/12/02/highlights-of-yast-development-sprint-28/</link>
+		<comments>https://lizards.opensuse.org/2016/12/02/highlights-of-yast-development-sprint-28/#respond</comments>
+		<pubDate>Fri, 02 Dec 2016 14:13:07 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Base System]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Network]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[Usability]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12141</guid>
+		<description><![CDATA[November is over, Santa Claus elves start to stress and the YaST team brings you one of the last reports of 2016. Let&#8217;s see what&#8217;s new in YaSTland. Harder to ignore installation warning The &#8220;installation settings&#8221; summary screen usually reports some non-critical errors displayed as a red text. Although the installation can proceed despite those [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>November is over, Santa Claus elves start to stress and the YaST team brings you one of the last reports of 2016. Let&#8217;s see what&#8217;s new in YaSTland.</p>
+<h3>Harder to ignore installation warning</h3>
+<p>The &#8220;installation settings&#8221; summary screen usually reports some non-critical errors displayed as a red text. Although the installation can proceed despite those errors, they are usually serious enough to lead to problems. That&#8217;s why we decided to introduce a change to highlight them a little bit more, making them harder to overlook.</p>
+<p>The following screenshot shows the newly introduced confirmation dialog, presented before proceeding with installation.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/11/warn.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/11/warn-300x227.png" alt="Preventing users to shoot their feet" width="300" height="227" class="aligncenter size-medium wp-image-12152" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/11/warn-300x227.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/11/warn-768x582.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/11/warn-1024x776.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/11/warn.png 1027w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Make DHCLIENT_SET_HOSTNAME configurable on a per-interface basis</h3>
+<p>But that&#8217;s not the only usability-oriented enhancement on this sprint. We also reworked a bit the network configuration dialog.</p>
+<p>For home users is very common to use a fixed hostname -set during installation- for our beloved linux box. But in some circumstances it&#8217;s better to set the hostname of the machine dynamically using DHCP, something YaST has always allowed to do by just ticking a checkbox that used to be in the network configuration screen. See &#8220;Change Hostname via DHCP&#8221; below.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/12/old-network.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/12/old-network-300x225.png" alt="The old network settings screen" width="300" height="225" class="aligncenter size-medium wp-image-12162" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/12/old-network-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/12/old-network.png 640w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>That checkbox used to modify the system-wide variable <code>DHCLIENT_SET_HOSTNAME</code>, which was fine in scenarios in which only one of the network interfaces was configured via DHCP. But with several network interfaces connected to different DHCP-enabled networks, some problems arose.</p>
+<p>During installation, if network configuration is used, <a href="https://en.opensuse.org/SDB:Linuxrc">Linuxrc</a> creates the <code>ifcfg</code> files with <code>DHCLIENT_SET_HOSTNAME='yes'</code> for all of the enabled or configured interfaces and this value has precedence over the global one.</p>
+<p>So the main problem was that YaST only allowed us to modify the global variable and setting it to &#8216;no&#8217; did nothing because it was enabled for some interface.</p>
+<p>During this sprint we have fixed that and now the user interface offers the possibility of choosing which DHCP interface will be used to decide the hostname.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/12/new-network.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/12/new-network-300x225.png" alt="The new network settings screen" width="300" height="225" class="aligncenter size-medium wp-image-12163" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/12/new-network-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/12/new-network.png 640w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Apart from choosing one of the existing interfaces, the new setting can also be set to &#8216;no&#8217; or to &#8216;any&#8217;. In any case, YaST will always configure the system-wide options and the interface specific ones in a consistent way, so the behavior is always predictable.</p>
+<p>But YaST is not the only way of configuring the network, so it&#8217;s always possible to have an unpredictable configuration. Fortunately, those potentially problematic scenarios will be detected by YaST and reported to the user.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/12/any-network.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/12/any-network-300x225.png" alt="Detecting dangerous scenarios in network settings" width="300" height="225" class="aligncenter size-medium wp-image-12164" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/12/any-network-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/12/any-network.png 640w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Partitioning in CASP</h3>
+<p>In the <a href="https://lizards.opensuse.org/2016/11/10/highlights-of-yast-development-sprint-27/">previous report</a> we already explained how are we improving the installer to support the definition of the ultra-streamlined installation process of SUSE CASP, the new <a href="http://kubernetes.io/">Kubernetes</a> based member of the SUSE family.</p>
+<p>In this sprint we introduced several additional changes to enable a different partitioning approach, more guided and automatic than ever. In a CASP node it makes no sense to use the advanced settings offered by our storage proposal, like encryption or LVM. Moreover, CASP relies on Btrfs to provide some of its cool and advanced features, like transactional updates.</p>
+<p>As a result, although the regular SUSE and openSUSE releases will keep offering all the current possibilities in the same way than ever, in CASP the partitioning step will be skipped and the automatically calculated proposal will be simply displayed in the installation summary.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/12/casp-installation-summary.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/12/casp-installation-summary-300x186.png" alt="The new CASP installation summary" width="300" height="186" class="aligncenter size-medium wp-image-12170" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-installation-summary-300x186.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-installation-summary-768x477.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-installation-summary-1024x636.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-installation-summary.png 1356w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Clicking on the proposal will allow to re-target the installation to a different disk (or disks) in a similar way than the regular installer, but the options will be more limited. Again, no easy way to use LVM, encryption, separate home or any file system type other than Btrfs.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/12/casp-select-partitions.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/12/casp-select-partitions-300x186.png" alt="Selecting the partitions in CASP, no proposal settings button" width="300" height="186" class="aligncenter size-medium wp-image-12171" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-select-partitions-300x186.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-select-partitions-768x477.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-select-partitions-1024x635.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-select-partitions.png 1352w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>The expert partitioner is still available during CASP installation, but using it will show an extra warning, since it implies a much bigger risk than using it in a regular SUSE or openSUSE system.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/12/casp-expert-partitioner-warning.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/12/casp-expert-partitioner-warning-300x186.png" alt="Expert partitioner warning in CASP" width="300" height="186" class="aligncenter size-medium wp-image-12172" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-expert-partitioner-warning-300x186.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-expert-partitioner-warning-768x477.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-expert-partitioner-warning-1024x636.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/12/casp-expert-partitioner-warning.png 1352w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Improved debugger integration</h3>
+<p>We have improved the Ruby debugger integration in YaST. So far you could start the debugger using the <code>y2debugger=1</code> boot option or by setting the <code>Y2DEBUGGER=1</code> environment variable. The new feature allows starting the Ruby debugger also later when the YaST module is already running.</p>
+<p>Simply press the <code>Shift+Ctrl+Alt+D</code> keyboard shortcut (<code>D</code> as debug) and it will start the Ruby debugger. It works during installation and also in installed system (just make sure the <code>byebug</code> Ruby gem is installed).</p>
+<p>Unfortunately this new feature works only in the Qt UI, the ncurses UI is not supported (currently it does not handle the debugging keyboard shortcut at all).</p>
+<p>After pressing the keyboard shortcut the debugger window will pop up:</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/11/debugger.gif" alt="New debugger integration" /></p>
+<h3>Storage reimplementation: it&#8217;s alive!</h3>
+<p>It took us one more sprint than originally expected, but finally we can say the testing ISO for the new storage stack is fully installable.</p>
+<p>We fixed the UEFI + MBR partition table scenario we already had almost working in the previous sprint (turns out it was not that broken in Tumbleweed after all) and we adapted yast2-bootloader to be also able to deal with legacy (i.e. no UEFI) booting using the new storage stack.</p>
+<p>As a nice result, our testing ISO can be used to install a perfectly functional system in both UEFI or legacy systems with the only requirement of having a pre-existing MBR partition table in the disk. It only shows a couple of error pop-ups related to the calculation of the proposal of software to be installed, but nothing that would prevent you from replacing whatever operating system you have with a new shiny openSUSE-based experiment.</p>
+<p>This milestone opens the door to start testing the new stack with openQA, the same system that helps to guarantee the robustness of all the recent SUSE and openSUSE versions.</p>
+<h3>Storage reimplementation: preparations for the storage proposal</h3>
+<p>Now that yast2-bootloader starts to be ready to work with the new storage stack in more and more scenarios, it&#8217;s time to adapt the only component that still complains during the installation. </p>
+<p>In order to make that task doable during the next sprint, we invested some time in this sprint analyzing the interaction between the software proposal calculator and the old storage layer. The outcome was <a href="https://github.com/yast/yast-storage-ng/blob/master/doc/software-requirements.md">a small document</a> detailing what needs to be adapted in the proposal and in the new stack. The perfect input for a task in the next sprint.</p>
+<h3>Help for power-users with short memory</h3>
+<p>Our beloved YaST is packed with <a href="https://en.opensuse.org/SDB:YaST_tricks">magic tricks</a> below the surface. Many of them are very useful to debug installation problems or to better understand how the YaST internals work. Unfortunately developers tend to not be that good at blindly memorizing stuff and the functionality is so well hidden that most newcomers would have hard times finding it&#8230; until now.</p>
+<p>We have added a couple of new keyboard shortcuts to show a summary of all the advanced hotkeys, so now you only have to remember one key combination instead of a dozen of them. In both text (ncurses) and graphical (Qt) mode, it will be enough to press <code>shift+F1</code> to get the advanced help displayed below. Since some terminal emulators could already use that combination, <code>ctrl+D F1</code> can also be used in the ncurses interface as an alternative.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/12/hotkey-help-qt.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/12/hotkey-help-qt-300x268.png" alt="Advanced Hotkeys help dialog" width="300" height="268" class="aligncenter size-medium wp-image-12167" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/12/hotkey-help-qt-300x268.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/12/hotkey-help-qt.png 589w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Contributions keep coming!</h3>
+<p>As we have already mentioned in previous sprint reports, an important part of our daily job as open source developers is helping casual (and not so casual) contributors to bring their ideas and code into YaST and related projects.</p>
+<p>This time that (hopefully not casual) contributor was <a href="https://github.com/dwaas">Devin Waas</a>, who wanted to improve the installation to make the life of cloud-lovers easier.</p>
+<p>For cloud guys out there retrieving logs of a failed installation <del>is</del> was a huge problem. Now, thanks to Devin, all you need is a running a rsyslog server and you&#8217;ll be able to easily access your installation logs from there.</p>
+<p><img class="aligncenter" src="//lizards.opensuse.org/wp-content/uploads/2016/11/dvw.png" alt="A drawing is worth a thousand words" /></p>
+<p>As a matter of fact, the newest Tumbleweed release allows us to specify the IP address of a remote server from the bootloader through the &#8220;Loghost flag&#8221;. Linuxrc will take care of setting up a UDP broadcast for dmesg contents and YaST installation logs.</p>
+<p>This is just a first step. Devin promised further improvements of our newly implemented remote logging system. And he codes better than he draws, so stay tuned! </p>
+<h3>Storage reimplementation: LVM-based proposal</h3>
+<p>As we already mentioned in previous reports, when we started to develop the partitioning proposal we first focused in the scenario of a partition-based proposal with one or several MBR-style partition tables. That looked like the most complex scenario due to the limited number of primary partitions, the alignment problems, the overhead introduced by the <a href="https://en.wikipedia.org/wiki/Extended_boot_record">EBR (extended boot record)</a> of every logical partition and so on.</p>
+<p>A couple of sprints ago, we got that working so we started to work on the LVM-based proposal. It took a little bit longer than expected but now we are able to generate LVM-based proposals for almost every possible scenario. The goal was to have them working in our mocked test cases. So probably the new LVM-based proposal cannot still be used to install a fully functional system, but it is backed by a full load of tests that prove we can handle many situations, from trivial to really tricky ones&#8230; and believe us, things can get quite tricky if you mix logical partitions with their EBR overhead and LVM volumes with their <a href="http://www.tldp.org/HOWTO/LVM-HOWTO/pe.html">PE size</a> rounding and their <a href="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Logical_Volume_Manager_Administration/lvm_metadata.html">metadata</a> overhead.</p>
+<h3>Bugs, bugs, bugs</h3>
+<p>In this sprint we kept the already commented approach of making the fix of low-priority and small bugs part of the Scrum process. As a result we accounted for approximately 50 deaths of those annoying creatures.</p>
+<h3>Conclusion</h3>
+<p>Looking at the report, we could say it was a quite successful sprint. But to be honest we were aiming even higher. Quite some interesting PBIs (features or bug-fixes in Scrum jargon) were almost done at the end of the sprint. But following Scrum philosophy, we never blog about almost-done stuff.</p>
+<p>Thus, if nothing goes wrong things will be even better in the next report in three weeks. So have a lot of fun trying the new stuff and stay tuned for more!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/12/02/highlights-of-yast-development-sprint-28/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>openSUSE project presentation at school, Nov 24th, 2016</title>
+		<link>https://lizards.opensuse.org/2016/11/29/opensuse-project-presentation-at-school-nov-24th-2016/</link>
+		<comments>https://lizards.opensuse.org/2016/11/29/opensuse-project-presentation-at-school-nov-24th-2016/#respond</comments>
+		<pubDate>Tue, 29 Nov 2016 20:12:46 +0000</pubDate>
+		<dc:creator><![CDATA[Efstathios Iosifidis]]></dc:creator>
+				<category><![CDATA[Ambassadors]]></category>
+		<category><![CDATA[GNOME]]></category>
+		<category><![CDATA[Marketing]]></category>
+		<category><![CDATA[Leap]]></category>
+		<category><![CDATA[openSUSE]]></category>
+		<category><![CDATA[project]]></category>
+		<category><![CDATA[school]]></category>
+		<category><![CDATA[Tumbleweed]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12138</guid>
+		<description><![CDATA[On November 16th there was the release of openSUSE Leap 42.2. On November 24th, I had the opportunity to present openSUSE Project at school. I was asked to make an introduction to FLOSS in general and more specific about openSUSE Project. The school was for middle aged people, for persons who quited school to work [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p><a href="https://dl.dropboxusercontent.com/u/20413076/opensuse/epal_24_nov/group.jpg" target="1"><img src="https://dl.dropboxusercontent.com/u/20413076/opensuse/epal_24_nov/group.jpg" width="70%" height="70%"></a></p>
+<p>On November 16th there was the release of <a href="https://news.opensuse.org/2016/11/16/optimal-release-for-linux-professionals-arrives-with-opensuse-leap-42-2/" target="1">openSUSE Leap 42.2</a>. On November 24th, I had the opportunity to present openSUSE Project at school.</p>
+<p>I was asked to make an introduction to FLOSS in general and more specific about openSUSE Project. The school was for middle aged people, for persons who quited school to work and conftibute financially to their families. There were 3 classes that they taught something computer related. It was a great opportunity for them to learn what FLOSS is and what makes openSUSE great Linux distro.<br />
+<span id="more-12138"></span><br />
+I busted the myth that &#8220;Linux is hard because you have to be a hacker, it&#8217;s terminal operated&#8221; I showed them how to install openSUSE Leap step by step (pictures) and also how to use GNOME (pictures). I mentioned our tools to make a very stable distro and finally I showed them that it&#8217;s not only a distro but there are people (the communtity) that take care of the software.</p>
+<p><a href="https://dl.dropboxusercontent.com/u/20413076/opensuse/epal_24_nov/presentation.jpg" target="1"><img src="https://dl.dropboxusercontent.com/u/20413076/opensuse/epal_24_nov/presentation.jpg" width="70%" height="70%"></a></p>
+<p>There were plenty of questions about linux software alternatives, how to install, if they can replace Ubuntu/Windows with openSUSE and what is perfect suit for specific systems. Each student took a DVD with stikers and a card with Greek community information. Professors will organize an install fest for their lab and/or laptops of their students.</p>
+<p>I would like to thank Douglas DeMaio for managing to send me DVDs and stickers and Alexandros Mouhtsis that managed with his professors to organize this presentation. Finally, I would like to thank <a href="https://www.flickr.com/photos/146573897@N06" target="1">Dimitrios Katsikas</a> for taking pictures.</p>
+<p><a href="https://dl.dropboxusercontent.com/u/20413076/opensuse/epal_24_nov/promo_material.jpg" target="1"><img src="https://dl.dropboxusercontent.com/u/20413076/opensuse/epal_24_nov/promo_material.jpg" width="70%" height="70%"></a></p>
+<p><a href="https://dl.dropboxusercontent.com/u/20413076/opensuse/epal_24_nov/promo_material_1.jpg" target="1"><img src="https://dl.dropboxusercontent.com/u/20413076/opensuse/epal_24_nov/promo_material_1.jpg" width="70%" height="70%"></a></p>
+<p>You can find the same <a href="http://eiosifidis.blogspot.gr/2016/11/opensuse-at-school.html" target="_blank">post at my blog</a>.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/11/29/opensuse-project-presentation-at-school-nov-24th-2016/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>YaST Team visits Euruko 2016</title>
+		<link>https://lizards.opensuse.org/2016/11/23/yast-team-visits-euruko-2016/</link>
+		<comments>https://lizards.opensuse.org/2016/11/23/yast-team-visits-euruko-2016/#respond</comments>
+		<pubDate>Wed, 23 Nov 2016 16:47:54 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Events]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12116</guid>
+		<description><![CDATA[As promised in previous posts, we want to share with you our experience and views from this year annual Ruby conference Euruko. Maybe &#8220;our&#8221; is too much to say, since we only sent one developer there. So to be precise, these are Josef Reidinger&#8217;s experience and views on the conference. This year Euruko took place [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>As promised in previous posts, we want to share with you our experience and views from this year annual Ruby conference <a href="http://euruko2016.org">Euruko</a>. Maybe &#8220;our&#8221; is too much to say, since we only sent one developer there. So to be precise, these are Josef Reidinger&#8217;s experience and views on the conference.</p>
+<p>This year Euruko took place in Sofia, capital of Bulgaria. It turned out to be a great conference place. Public transport works very well, everyone speak English and even when it uses Cyrilic alphabet, almost everything is written also in Latin one.</p>
+<p>That being said, let&#8217;s talk about the conference content. Fortunately all the presentations were recorded so you can <a href="https://www.youtube.com/channel/UChGs1td4ViQFqT0jlvkyUJg">watch them yourself</a>. But since it would be quite some hours of video to go through, we have reviewed some presentations for you including access to the corresponding videos.</p>
+<h3>Highlights</h3>
+<p>Let&#8217;s start with the three presentation Josef specially recommend to watch.</p>
+<p><b>Keynote by Matz</b></p>
+<p>He speaks about how Ruby 3 will probably look in distant future. With &#8220;distant future&#8221; meaning &#8220;for sure not in next two years&#8221;. If you cannot wait, it&#8217;s worth mentioning that Ruby 2.4 will be released on December.</p>
+<p>Ruby 3 will use guild membership concurrency model. The most interesting part of the talk is digging into rationale of typed versus non-typed languages and what can be the Ruby future in that regard.</p>
+<p><iframe width="500" height="281" src="https://www.youtube.com/embed/8aHmArEq4y0?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
+<p><b>Rules, Laws and Gently Guidelines by Andrew Radev</b></p>
+<p>Interesting view about common design principles, common mistakes when applying them and looking to them from different angles. Also explaining how to handle situations in which several design principles seem to contradict each other.</p>
+<p><iframe width="500" height="281" src="https://www.youtube.com/embed/BDXQ4pcbEBA?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
+<p><b>Elixir by Jose Valim</b></p>
+<p>Interesting intro to Elixir language. What it is, why it make sense to use it and what are its benefits. Josef&#8217;s impression was that Elixir&#8217;s idea is similar to isolated micro-services communicating via messages, with nice introspection and scalability.</p>
+<p>But we have more team members with something to say about Elixir. Like Imobach, who has been playing with Elixir (and <a href="http://www.phoenixframework.org/">Phoenix</a>) for some time now. And Imobach really likes Elixir, so he would like to add some more bits of information for those who are interested.</p>
+<p>For example, he would like to highlight that Elixir uses BEAM, the Erlang virtual machine, so great support for concurrency is backed in the platform. Concurrency sits on the concept of Erlang processes and it&#8217;s pretty common to use them for all kind of tasks (from computation to storing state, etc.). Imobach would like to encourage all developers out there to take a look to <a href="https://en.wikipedia.org/wiki/Open_Telecom_Platform">OTP (Open Telecom Platform)</a>. Who needs micro-services at all? </p>
+<p>Last but not least, take into account that Elixir is a functional language, so if you have an object-oriented mindset (like most Ruby developers) it will take some time to wrap your head around it.</p>
+<p><iframe width="500" height="281" src="https://www.youtube.com/embed/xhwnHovnq_0?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
+<h3>Other presentations</h3>
+<p><b>Little Snippets by Xavier Noria</b></p>
+<p>Summary of common inefficiency in small snippets. Small things that matter, although most of them should be already known by the average Ruby developer. (<a href="https://www.youtube.com/watch?v=mC9TyVeER_8">Video</a>)</p>
+<p>Since we mention the topic, some YaST team members has found <a href="https://github.com/JuanitoFatas/fast-ruby">this cheat sheet</a> by Juanito Fatas about Ruby optimization to be quite useful.</p>
+<p><b>Rails + Kafka by Terence Lee</b></p>
+<p>Apache Kafka is yet another messaging system. This talk did not manage to convince Josef to use it, but maybe it makes sense in some scenarios like HPC or HA. (<a href="https://www.youtube.com/watch?v=yl3JmF3n2bQ">Video</a>)</p>
+<p><b>Graphql on Rails by Marc-Andre Giroux</b></p>
+<p>The typical REST setup is sometimes not scalable enough due to the excess of endpoints. The Graphql language is designed to specify what resources are needed from a server in a single query. The result is returned as JSON and the request specification looks also similar to JSON. Caching is done on client side. Interesting for web stuff and already used by Facebook, Shopify and others. (<a href="https://www.youtube.com/watch?v=_V96jduEvjY">Video</a>)</p>
+<p><b>Evolution of engineering on call team by Grace Chang</b></p>
+<p>How to maintain services, how to scale when the grow, preventing burnout and so on. Specially interesting for us since there are many similarities with YaST maintenance. Maybe the end of the talk is a bit theoretic and idealistic. (<a href="https://www.youtube.com/watch?v=u_7wrPXaSto">Video</a>)</p>
+<p><b>Sprockets by Rafael Franca</b></p>
+<p>Not specially interesting intro to assets generation used by Rails. People doing some assets generation with Rails would most likely already know all the content. (<a href="https://www.youtube.com/watch?v=rbM_1wRVfeI">Video</a>)</p>
+<p><b>Contribute to Ruby core by Hiroshi Shibata</b></p>
+<p>Presentation about Ruby core development infrastructure, rules, etc. Certainly not the best talk ever. (<a href="https://www.youtube.com/watch?v=IRfsakcZJKw">Video</a>)</p>
+<p><b>Consequences of insightful algorithms by Carina C. Zona</b></p>
+<p>Interesting presentation about conflicts between algorithms and real humans, especially with data-mining. Unfortunately, the second half turned to be too emotional and not technical enough for Josef&#8217;s taste :). (<a href="https://www.youtube.com/watch?v=bp4yFKw_1QM">Video</a>)</p>
+<p><b>Viewing Ruby Blossom &#8211; Hamani by Anton Davydov</b></p>
+<p>Introduction to yet another Ruby web framework. Not that interesting for us. (<a href="https://www.youtube.com/watch?v=3L6I4UoK8xM">Video</a>)</p>
+<p><b>A Year of Ruby, Together by Andre Arko</b></p>
+<p>Introduction on how the open source community infrastructure behind Rubygems and Bundler is ran. How they get money to improve stuff, how they maintain their servers&#8230; Good talk about hard times keeping open source infrastructure alive. Interesting talk for any open source project. (<a href="https://www.youtube.com/watch?v=SJddsEfvcW8">Video</a>)</p>
+<p><b>What I Have Learned from Organizing Remote Internship for Ruby Developers by Ivan Nemytchenko</b></p>
+<p>Talk describing an attempt to scale internship for a lot of students. Josef had a small chat with the author about Google Summer of Code after the presentation. He looked interested. (<a href="https://www.youtube.com/watch?v=H-K0ZKOclBU">Video</a>)</p>
+<p><b>The Illusion of Stable APIs by Nick Sutterer</b></p>
+<p>Not Josef&#8217;s cup of tea. The presenter probably went a little bit too far trying to be funny all the time. The core of the presentation was about three examples of API that needed to be changed &#8220;just&#8221; because the rest of the world changed. So the whole presentation can be shortened to one sentence &#8211; your API will only remain static if the world remains static. (<a href="https://www.youtube.com/watch?v=mvHwTtsIH8g">Video</a>)</p>
+<h3>Conclusion</h3>
+<p>That was all from Sofia. See you again in approximately one week, just in time for the report of our 28th Scrum sprint.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/11/23/yast-team-visits-euruko-2016/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of YaST development sprint 27</title>
+		<link>https://lizards.opensuse.org/2016/11/10/highlights-of-yast-development-sprint-27/</link>
+		<comments>https://lizards.opensuse.org/2016/11/10/highlights-of-yast-development-sprint-27/#comments</comments>
+		<pubDate>Thu, 10 Nov 2016 11:17:57 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Base System]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12095</guid>
+		<description><![CDATA[Another three weeks of development come to an end&#8230; and our usual report starts. Take a look to what we have been cooking. Read-only proposal modules This week, during SUSECon 2016, SUSE announced an exciting upcoming new product. SUSE CASP &#8211; a Kubernetes based Container As a Service Platform. That has, of course, some implications [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Another three weeks of development come to an end&#8230; and our usual report starts. Take a look to what we have been cooking. </p>
+<h3>Read-only proposal modules</h3>
+<p>This week, during <a href="http://www.susecon.com/">SUSECon 2016</a>, SUSE announced an exciting upcoming new product. SUSE CASP &#8211; a <a href="http://kubernetes.io/">Kubernetes</a> based Container As a Service Platform.</p>
+<p>That has, of course, some implications for the installer, like the need of some products (like CASP) to specify a fixed configuration for some subsystems. For example, an established selection of packages. The user should not be allowed to change those fixed configurations during installation.</p>
+<p>We have implemented a possibility to mark some modules in the installation proposal as read-only. These read-only modules then cannot be started from the installer and therefore their configuration is kept at the default initial state.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/11/readonly.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/11/readonly-300x225.png" alt="Software and firewall proposals as read-only" width="300" height="225" class="aligncenter size-medium wp-image-12099" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/11/readonly-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/11/readonly-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/11/readonly.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>In this sprint we have implemented a basic support in the proposal framework, in the future we could improve the respective proposal modules to better handle the read-only mode.</p>
+<h3>Per product Btrfs subvolumes handling</h3>
+<p>The ability to have read-only proposals is not the only improvement we have introduced in YaST to make SUSE CASP possible.</p>
+<p>When Btrfs is used during the installation, YaST2 proposes a list of subvolumes to create. Unfortunatelly, that list is hard-coded and it&#8217;s the same for every (open)SUSE product&#8230; until now.</p>
+<p>Starting on yast2-storage 3.1.103.1, a list of subvolumes can be defined in the product&#8217;s control file along with additional options (check out <a href="https://github.com/yast/skelcd-control-SLES/blob/master/control/control.SLES.xml#L190">SLES</a> and <a href="https://github.com/yast/skelcd-control-openSUSE/blob/master/control/control.openSUSE.xml#L297">openSUSE</a> examples to learn more).</p>
+<pre>
+&lt;subvolumes config:type="list"&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;boot/grub2/i386-pc&lt;/path&gt;
+    &lt;archs&gt;i386,x86_64&lt;/archs&gt;
+  &lt;/subvolume&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;home&lt;/path&gt;
+  &lt;/subvolume&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;opt&lt;/path&gt;
+  &lt;/subvolume&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;var/lib/libvirt/images&lt;/path&gt;
+    &lt;copy_on_write config:type="boolean"&gt;false&lt;/copy_on_write&gt;
+  &lt;/subvolume&gt;
+&lt;/subvolumes&gt;
+</pre>
+<p>This specification supports:</p>
+<ul>
+<li>Disabling copy-on-write for a given subvolume (it&#8217;s enabled by default).</li>
+<li>Enabling the creation of a subvolume only for a set of architectures.</li>
+</ul>
+<h3>Improved AutoYaST Btrfs subvolumes handling</h3>
+<p>AutoYaST Btrfs subvolumes handling has been also improved. Using almost the same syntax as for product control files, you can disable the <code>CoW</code> behavior for a given subvolume.</p>
+<p>Of course, if you don&#8217;t need such a feature, you won&#8217;t need to adapt your profiles to the new syntax as it&#8217;s backward compatible. You can also mix both of them:</p>
+<pre>
+&lt;subvolumes config:type="list"&gt;
+  &lt;subvolume&gt;home&lt;/subvolume&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;var/lib/libvirt/images&lt;/path&gt;
+    &lt;copy_on_write config:type="boolean"&gt;false&lt;/copy_on_write&gt;
+  &lt;/subvolume&gt;
+&lt;/subvolumes&gt;
+</pre>
+<p>On the other hand, if you&#8217;re running SLES, you&#8217;ll know that a subvolume called <code>@</code> is used as the default Btrfs subvolume. Now is possible to turn-off such behavior in the profile&#8217;s general section.</p>
+<pre>
+&lt;general&gt;
+  &lt;btrfs_set_subvolume_default_name config:type="boolean"&gt;false&lt;/btrfs_set_subvolume_default_name&gt;
+&lt;/general&gt;
+</pre>
+<h3>Disable installer self-update by default</h3>
+<p>We have talked many times in this blog about the new self-update functionality for the installer. As expected, this functionality will debut in SLE-12-SP2 but with a small change in the original plan. In order to ensure maximum consistency in the behavior of SLE-12-SP1 and SP2 installers, the self-update functionality will be disabled by default. Not a big deal, since enabling it to get the latest fixes will be just a matter of adding a boot option in the initial installation screen.</p>
+<h3>Storage reimplementation: adapted EFI proposal in yast2-bootloader</h3>
+<p>The previous report about the status of the storage stack reimplementation finished with the following cliffhanger &#8220;<i>we have in place all the ingredients to cook an installable ISO</i>&#8220;. So, as expected, we worked during this sprint in adapting the bootloader proposal to the new storage layer. As you can see in the following screenshot, we succeeded and the installer can already propose a valid grub2 setup to boot an EFI system.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi-300x225.png" alt="EFI proposal with the storage-ng ISO" width="300" height="225" class="aligncenter size-medium wp-image-12100" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Does that mean that the testing ISO for the new storage stack is already fully installable? Unfortunately not. Why not, you ask? The reason is, in fact, kind of fun.</p>
+<p>The current partitioning proposal only works with MS-DOS style partition tables because we wanted to address the most complicated case first. On the other hand, we intentionally restricted the adaptation of the bootloader proposal to the EFI scenario. And you know what? We found out that combination (MS-DOS partition table + EFI) <a href="https://bugzilla.suse.com/show_bug.cgi?id=1008289">does not currently work</a> in Tumbleweed, so it neither does in our Tumbleweed-based testing ISO.</p>
+<p>We will work during the following sprint to support another scenario. And hopefully we will not choose again an unsupported or broken one. <img src="https://s.w.org/images/core/emoji/2/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<h3>Letting libYUI run free: first visible steps</h3>
+<p>As you know, YaST has both a graphical and a textual interface. They run on the same code thanks to an abstraction layer called LibYUI. Originally it served YaST only, but over time other projects started using it, notably the admin panel in Mageia. Moreover, the developers of those projects started to contribute fixes and improvements to LibYUI&#8230; faster than we can cope with.</p>
+<p>Recently we decided to give the people outside the YaST team more power in the LibYUI project. To make that possible ensuring it does not affect YaST stability, we have been enabling more continuous integration tests.</p>
+<p>As a first fruit of the revamped collaboration, we have merged a fix contributed by Angelo Naselli of Mageia regarding selection of tree items. As soon as we complete our continuous integration setup (of course we will keep you informed), more fixes and improvements will come for sure.</p>
+<h3>More bug squashing and bug paleontology</h3>
+<p>In the <a href="https://lizards.opensuse.org/2016/10/20/highlights-of-yast-development-sprint-26/">previous report</a> we presented our new effort to integrate the fix of low-priority bugs into the Scrum process. During this sprint we refined the idea a little bit more, distinguishing two separate concepts (each of them with its own <a href="https://www.scrumalliance.org/community/articles/2007/march/glossary-of-scrum-terms#1130">PBI</a>) &#8211; fixing of existing bugs and closing of too old ones.</p>
+<p>The first one doesn&#8217;t need much explanation. We managed to fix around 25 non-critical bugs in YaST and if you are using Tumbleweed you are probably already benefiting from the result.</p>
+<p>The second task was not exactly about fixing bugs present in the software, but about cleaning bugzilla from bug reports that were simply too old to be relevant any more. Like bugs affecting very old versions of openSUSE that cannot be reproduced in openSUSE 13.2 or Leap. We must be realistic about releases that are already out of support and the limited human resources we have. We closed around 80 of those ancient bugs.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/11/no_country_for_old_bugs.jpg"><img src="//lizards.opensuse.org/wp-content/uploads/2016/11/no_country_for_old_bugs-300x169.jpg" alt="no_country_for_old_bugs" width="300" height="169" class="aligncenter size-medium wp-image-12105" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/11/no_country_for_old_bugs-300x169.jpg 300w, https://lizards.opensuse.org/wp-content/uploads/2016/11/no_country_for_old_bugs.jpg 569w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>So overall, we cleaned up around one hundred bugs from our queue. Still a long way to have a bug-free YaST, but undoubtedly a step in the right direction. </p>
+<h3>More coming</h3>
+<p>We are already working in the next sprint that will hopefully bring several new improvements for CASP, quite relevant progress in the storage reimplementation, several usability improvements, some bugfixes and even some news about this blog.</p>
+<p>To make sure you don&#8217;t get bored while waiting we are also planning to finally publish the report about our visit to <a href="http://euruko2016.org/">Euruko 2016</a>.</p>
+<p>Stay tuned!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/11/10/highlights-of-yast-development-sprint-27/feed/</wfw:commentRss>
+		<slash:comments>4</slash:comments>
+		</item>
+		<item>
+		<title>Basic Nextcloud installation on openSUSE Leap</title>
+		<link>https://lizards.opensuse.org/2016/10/28/nextcloud-installation-on-opensuse-leap/</link>
+		<comments>https://lizards.opensuse.org/2016/10/28/nextcloud-installation-on-opensuse-leap/#respond</comments>
+		<pubDate>Fri, 28 Oct 2016 15:09:09 +0000</pubDate>
+		<dc:creator><![CDATA[Efstathios Iosifidis]]></dc:creator>
+				<category><![CDATA[Apache]]></category>
+		<category><![CDATA[Documentation]]></category>
+		<category><![CDATA[Server]]></category>
+		<category><![CDATA[42.1]]></category>
+		<category><![CDATA[cloud]]></category>
+		<category><![CDATA[Leap]]></category>
+		<category><![CDATA[nextcloud]]></category>
+		<category><![CDATA[openSUSE]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12089</guid>
+		<description><![CDATA[I see the official documentation has full tutorial for RHEL 6 or CentOS 6 and RHEL 7 or CentOS 7. The main documentation covers Ubuntu 14.04 LTS openSUSE already has the Nextcloud client packaged in Tumbelweed and the Server is in the PHP extra repo! Personally, I prefer to install eveything from official repository, so [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p><img src="https://en.opensuse.org/images/0/0f/Nextcloud.png" alt="Nextcloud Logo" width="40%" height="40%" /></p>
+<p>I see the official documentation has full tutorial for <a href="https://docs.nextcloud.com/server/10/admin_manual/installation/php_54_installation.html" target="1">RHEL 6 or CentOS 6</a> and <a href="https://docs.nextcloud.com/server/10/admin_manual/installation/php_55_installation.html" target="1">RHEL 7 or CentOS 7</a>. The main documentation covers <a href="https://docs.nextcloud.com/server/10/admin_manual/installation/source_installation.html" target="1">Ubuntu 14.04 LTS</a></p>
+<p>openSUSE already has the <a href="https://software.opensuse.org/search?utf8=%E2%9C%93&amp;q=nextcloud&amp;search_devel=false&amp;search_unsupported=false&amp;baseproject=openSUSE%3AFactory" target="1">Nextcloud client packaged in Tumbelweed and the Server is in the PHP extra repo!</a> Personally, I prefer to install eveything from official repository, so when an update is available, I can have it without a glitch. This tutorial describes how to install Nextcloud using command line. I followed the official documentation of <a href="https://docs.nextcloud.com/server/10/admin_manual/installation/source_installation.html" target="1">Ubuntu 14.04 LTS installation</a>.</p>
+<p>Why choose <a href="https://en.opensuse.org/Portal:Leap" target="1">openSUSE Leap</a>? openSUSE Leap is a brand new way of building openSUSE and is new type of hybrid Linux distribution. Leap uses source from <a href="https://www.suse.com/promo/sle/" target="1">SUSE Linux Enterprise (SLE)</a>, which gives Leap a level of stability unmatched by other Linux distributions, and combines that with community developments to give users, developers and sysadmins the best stable Linux experience available. Contributor and enterprise efforts for Leap bridge a gap between matured packages and newer packages found in openSUSE’s other distribution Tumbleweed. You can download openSUSE Leap from the site <a href="https://software.opensuse.org/" target="1">https://software.opensuse.org/</a>.<br />
+<span id="more-12089"></span><br />
+Make sure that ssh (sshd) is enabled and also the firewall either is disabled or <a href="https://en.opensuse.org/SuSEfirewall2" target="1">make an exception to the apache and ssh services</a>. You can also set a static IP (<a href="http://eiosifidis.blogspot.gr/2015/05/set-static-ip-on-your-opensuse-raspberry-pi.html" target="1">check out how</a>).</p>
+<p>First of all, let&#8217;s install the required and recommended modules for a typical Nextcloud installation, using Apache and MariaDB, by issuing the following commands in a terminal:</p>
+<div class="code">zypper in apache2 mariadb apache2-mod_php5 php5-gd php5-json php5-fpm php5-mysql php5-curl php5-intl php5-mcrypt php5-zip php5-mbstring php5-zlib</div>
+<p><b>Create Database (optional since it&#8217;ll create eveything automatically)</b>Next step, create a database. First of all start the service.</p>
+<div class="code">systemctl start mysql.service<br />
+systemctl enable mysql.service</div>
+<p>The root password is empty by default. That means that you can press enter and you can use your root user. That&#8217;s not safe at all. So you can set a password using the command:</p>
+<div class="code">mysqladmin -u root password newpass</div>
+<p>Where newpass is the password you want.</p>
+<p>Now you set the root password, create the database.</p>
+<blockquote><p>mysql -u root -p<br />
+#you&#8217;ll be asked for your root passwordCREATE DATABASE nextcloudb;</p>
+<p>GRANT ALL ON nextcloudb.* TO ncuser@localhost IDENTIFIED BY &#8216;dbpass&#8217;;</p></blockquote>
+<p>Database user: <b>ncuser</b><br />
+Database name: <b>nextcloudb</b><br />
+Database user password: <b>dbpass</b></p>
+<p>You can change the above information accordingly.</p>
+<p><b>PHP changes</b><br />
+Now you should edit the php.ini file.</p>
+<blockquote><p>nano /etc/php5/apache2/php.ini</p></blockquote>
+<p>change the values</p>
+<blockquote><p>post_max_size = 50G<br />
+upload_max_filesize = 25G<br />
+max_file_uploads = 200<br />
+max_input_time = 3600<br />
+max_execution_time = 3600<br />
+session.gc_maxlifetime = 3600<br />
+memory_limit = 512M</p></blockquote>
+<p>and finally enable the extensions.</p>
+<blockquote><p>extension=php_gd2.dll<br />
+extension=php_mbstring.dll</p></blockquote>
+<p><b>Apache Configuration</b><br />
+You should enable some modules. Some might be already enabled.</p>
+<blockquote><p>a2enmod php5<br />
+a2enmod rewrite<br />
+a2enmod headers<br />
+a2enmod env<br />
+a2enmod dir<br />
+a2enmod mime</p></blockquote>
+<p>Now start the apache service.</p>
+<blockquote><p>systemctl start apache2.service<br />
+systemctl enable apache2.service</p></blockquote>
+<p><b>Install Nextcloud from source code (option 1, preferable)</b><br />
+Before the installation, create the data folder and give the right permissions (preferably outside the server directory for security reasons). I created a directory in the <i>/mnt</i> directory. You can mount a USB disk, add it to fstab and save your data there. The commands are:</p>
+<blockquote><p>mkdir /mnt/nextcloud_data<br />
+chmod -R 0770 /mnt/nextcloud_data<br />
+chown wwwrun /mnt/nextcloud_data</p></blockquote>
+<p>Now download Nextcloud (find the latest version at <a href="https://nextcloud.com/install/" target="1">https://nextcloud.com/install/</a>). Then unzip and move the folder to the server directory.</p>
+<blockquote><p>wget https://download.nextcloud.com/server/releases/nextcloud-10.0.0.zip<br />
+unzip nextcloud-10.0.0.zip<br />
+cp -r netcloud /srv/www/htdocs<br />
+chown -R wwwrun /srv/www/htdocs/nextcloud/</p></blockquote>
+<p>Make sure that everything is OK and then delete the folder nextcloud and nextcloud-10.0.0.zip from the root (user) directory.</p>
+<p>Now open your browser to the server IP/nextcloud</p>
+<p><a href="https://dl.dropboxusercontent.com/u/20413076/nextcloud/opensuse/nextcloud_install.png" target="1"><img src="https://dl.dropboxusercontent.com/u/20413076/nextcloud/opensuse/nextcloud_install.png" width="80%" height="80%" /></a>Set your administrator username and password.<br />
+Your data directory is: /mnt/nextcloud_data<br />
+Regarding database, use the following.<br />
+Database user: <b>ncuser</b><br />
+Database name: <b>nextcloudb</b><br />
+Database user password: <b>dbpass</b></p>
+<p>Wait until it ends the installation. The page you&#8217;ll see is the following.</p>
+<p><a href="https://dl.dropboxusercontent.com/u/20413076/nextcloud/opensuse/nextcloud_first_login.png" target="1"><img src="https://dl.dropboxusercontent.com/u/20413076/nextcloud/opensuse/nextcloud_first_login.png" width="80%" height="80%" /></a></p>
+<p><b>Install Nextcloud using the respository (option 2)</b></p>
+<p>If you want to have automatic updates of your Nextcloud instance when there&#8217;s a new version, you can add the repository. There are packages available for openSUSE Leap 42.1, 42.2 and Tumbleweed (we recommend openSUSE Leap 42.1). You should be an administrator, so you can install Nextloud on your server.</p>
+<p>1. Add the Nextcloud repository.<br />
+<strong>openSUSE_Leap_42.2</strong></p>
+<blockquote><p>zypper ar http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Leap_42.2/ Nextcloud</p></blockquote>
+<p><strong>openSUSE_Leap_42.1</strong></p>
+<blockquote><p>zypper ar http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Leap_42.1/ Nextcloud</p></blockquote>
+<p><strong>openSUSE_Leap_Tumbleweed</strong></p>
+<blockquote><p>zypper ar http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/ Nextcloud</p></blockquote>
+<p>2. Refresh your repositories</p>
+<blockquote><p>zypper refresh</p></blockquote>
+<p>3. Install Nextcloud (be careful you have to install LAMP first and change permissions of the files).</p>
+<blockquote><p>zypper install nextcloud</p></blockquote>
+<p>4. Open http://serverIP/nextcloud to install your instance (admin user account). Be careful to create another folder with the proper permissions for your data (as described).</p>
+<p>5. Login and use Nextloud.</p>
+<p>For more information about Nextcloud on openSUSE, check <a href="https://en.opensuse.org/SDB:Nextcloud" target="_blank">openSUSE wiki</a>.</p>
+<p>For any changes, check the <a href="https://github.com/iosifidis/nextcloud-opensuse-leap" target="1">github page</a>.</p>
+<p>For more configuration, you can follow the <a href="https://docs.nextcloud.com/server/10/admin_manual/contents.html" target="1">official documentation</a>. That was the basic installation on openSUSE Leap.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/28/nextcloud-installation-on-opensuse-leap/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of YaST development sprint 26</title>
+		<link>https://lizards.opensuse.org/2016/10/20/highlights-of-yast-development-sprint-26/</link>
+		<comments>https://lizards.opensuse.org/2016/10/20/highlights-of-yast-development-sprint-26/#comments</comments>
+		<pubDate>Thu, 20 Oct 2016 12:36:54 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Localization]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[Usability]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12055</guid>
+		<description><![CDATA[We did our best to keep you entertained during this development sprint with a couple of blog posts ([1] and [2]). But now the sprint is over and it&#8217;s time for a new report. Squashing low priority bugs One of the main reasons to adopt Scrum was to ensure we make a good use of [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>We did our best to keep you entertained during this development sprint with a couple of blog posts (<a href="https://lizards.opensuse.org/?p=12019">[1]</a> and <a href="https://lizards.opensuse.org/?p=12030">[2]</a>). But now the sprint is over and it&#8217;s time for a new report.</p>
+<h3>Squashing low priority bugs</h3>
+<p>One of the main reasons to adopt Scrum was to ensure we make a good use of our development resources (i.e. developers&#8217; time and brains) focusing on things that bring more value to our users. In the past we had the feeling that many important things were always postponed because the developers were flooded by other not so important stuff. Now that feeling is gone (to a great extent) and we have a more clear and shared view of the direction of our development efforts.</p>
+<p>But there is always a drawback. We have accumulated quite some unsolved low-priority bugs. That was an expected consequence, but still it was starting to feel wrong. On one hand, it makes us feel uncomfortable &#8211; replying &#8220;this will have to wait&#8221; so often is not nice, even if it&#8217;s for the shake a bigger goal. On the other hand, the amount of low-priority stuff was affecting the signal/noise ratio on Bugzilla, making harder to distinguish the important stuff.</p>
+<p>So far, dealing with those low-priority bug was something that each developer did on his own, as permitted by the time dedicated to Scrum. In sprint 26 we decided to make that effort an explicit part of the process and to devote a significant portion of the sprint to it. As a result we closed or reassigned a total of 135 bugs that were just sitting in our list.</p>
+<p>Yes, you did read it right. One hundred and thirty five bugs.</p>
+<h3>Storage reimplementation: our testing ISO can already destroy your data</h3>
+<p>On the previous sprint we already showed a screenshot of the installer using the new storage stack to calculate a partitioning proposal. Now the installer can go one step further. As you can see on this animation, the changes are now committed to the disk, meaning the system is actually partitioned, formatted and installed.</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/demo_commit_to_disk.gif" alt="Installation with the new storage stack"></p>
+<p>The process is interrupted after installing the software, when trying to configure and install the bootloader. That was expected because yast2-bootloader has still not been adapted to use the new stack. First of all, because we wanted to leave some fun for sprint 27. But also because we used this sprint (26) to document <a href="https://github.com/yast/yast-bootloader/blob/master/doc/boot_storage_needed_info.md">all the requirements of yast2-bootloader</a> in relation to the new storage stack. Now we have in place all the ingredients to cook an installable ISO.</p>
+<h3>Automatic update of translation files</h3>
+<p>Recently openSUSE has adopted <a href="https://weblate.org">Weblate</a> to perform and coordinate the translation of the software and the project&#8217;s web pages. The <a href="https://l10n.opensuse.org/">openSUSE&#8217;s Weblate instance</a> enables everybody (from dedicated translators to casual contributors) to take part in the process and makes possible to coordinate the translations of openSUSE with the ones for SUSE Enterprise Linux, boosting collaboration between the translators of both projects.</p>
+<p>As YaST developers, is of course our responsibility to ensure that openSUSE&#8217;s Weblate contains always the latest English strings to be translated. Making our developer&#8217;s life easier sometimes not only brings advantages for us but also for our users. Until now, after each code change we had to keep in mind to trigger the translation process for every added or changed English text. Sometimes we were not quick enough so that some English leftovers remained in our awesome YaST when being used in one of the 20 languages where the translation is normally 100% complete.</p>
+<p>Now we finally set up a <a href="https://ci.opensuse.org/">Jenkins</a> job to automate the process of triggering the translation update after code changes. This saves the developers some work and makes the update of translations even faster.</p>
+<p>Looking at <a href="https://l10n.opensuse.org/languages/">Weblate numbers</a>, you can see we have 20 languages that are about 100% translated, another 20 that are translated more than 75% and 37 languages which are translated less than 75%. So we still need some help to bring all languages to 100% coverage. If you are willing to contribute, why not join our team of translators? Check out <a href="https://en.opensuse.org/openSUSE:Localization_guide">the localization guide</a> to get in contact with the coordinators of your preferred language to learn about how to contribute with translations, reviews or by any other mean.</p>
+<h3>Ensure installation of packages needed for booting</h3>
+<p>We got some reports of systems not being able to work after the installation in scenarios in which the user had customized the list of packages to install. That happened because, although the bootloader component of YaST pre-selects for installation all the needed packages, the user can override that selection and manually disable the installation of those packages.</p>
+<p>To prevent this situation, or at least to increase awareness of it, the installer now alerts in the summary screen (the last step before proceeding to installation) if some of the required packages is missing, as you can see in the screenshot below. We still allow the users to shoot their own feet if they insist, but now we warn them very clearly.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/softw.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/softw-300x226.png" alt="Warning about de-selected Grub2 package" width="300" height="226" class="aligncenter size-medium wp-image-12057" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/softw-300x226.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/softw-768x578.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/softw-1024x770.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/10/softw.png 1025w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Progress in the low-vision accessibility of the installer</h3>
+<p>During this sprint, we have been working to make the (open)SUSE installer accessible to people with low-vision impairment. We already <a href="https://lizards.opensuse.org/?p=12019">blogged about it</a> looking for feedback.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/highc.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/highc-300x225.png" alt="One of the new color modes available in the installer" width="300" height="225" class="aligncenter size-medium wp-image-12065" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/highc-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/highc-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/highc.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>In a few days, some changes will land in Tumbleweed:</p>
+<ul>
+<li>Alternative style selection (color and font-sizes). Currently, we offer four options: default (no changes), high contrast (cyan/green/white/black), white on black and cyan on black. Those styles are just a proof of concept in order to test the code changes and, most important, to get feedback from you.</li>
+<li>A <a href="https://bugzilla.suse.com/show_bug.cgi?id=768112">long-standing issue</a>, which prevented to switch to high-contrast mode during installation (shift+F4), has been fixed.</li>
+</ul>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc-300x225.png" alt="Style selection at the beginning of installation" width="300" height="225" class="aligncenter size-medium wp-image-12066" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc.png 800w" sizes="(max-width: 300px) 100vw, 300px" /></a><br />
+Although we have made some progress, it is still an ongoing effort and we hope to release more improvements during the upcoming weeks.</p>
+<h3>Recover from broken bootloader configuration</h3>
+<p>There are situations in which YaST Bootloader is not able to read the system configuration. For example, when the udev device originally used by Grub2 is no longer available. In the past that leaded to YaST crashes, requiring a manual fix of the bootloader configuration files. Now YaST correctly detects the situation and offers the option to propose a new configuration with correct devices.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/bootl.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/bootl-300x170.png" alt="YaST bootloader fixing a broken configuration" width="300" height="170" class="aligncenter size-medium wp-image-12058" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/bootl-300x170.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bootl-768x435.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bootl-1024x580.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bootl.png 1346w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Disable autorefresh by default in local media</h3>
+<p>We have changed the default autorefresh flag for the new repositories added by YaST. In the past the autorefresh was enabled for all repositories except CD/DVD media and ISO files.</p>
+<p>With the new defaults the autorefresh is enabled only for remote repositories (like http, ftp, nfs,&#8230;). The reason is that some local repositories might not be always available (e.g. external hard disk, USB flash drive,&#8230;) and the automatic refresh might cause ugly errors when starting the package manager.</p>
+<p>Of course, you can still manually change the autorefresh flag after adding a repository if you need a different value.</p>
+<p><i>Note: The default has been changed in Tumbleweed distribution only, Leap 42.2 or SLE-12-SP2 keep the old defaults. The zypper behavior is unchanged as well, it by default disables autorefresh for all repositories. Only repositories imported from a .repo file have autorefresh enabled. See <code>man zypper</code> for more details.</i></p>
+<h3>Tons of improvements in network bridge handling</h3>
+<p>YaST Network is Swiss Army knife for network configuration which comprehends the management of routing, bonding, bridging and many other things. But, to be honest, the management of bridges was not in the best possible shape. It had quite some usability problems and it was not 100% consistent with the way in which bridges are managed nowadays by <a href="https://en.opensuse.org/Portal:Wicked">Wicked</a> in (open)SUSE. Until now!</p>
+<p>This <a href="https://github.com/yast/yast-network/pull/448">pull request</a> with several screenshots and animations tries to summarize all the changes that have been done during this sprint. Like adapting old configuration files to the new conventions or unifying the UI to make it consistent with the one for managing bonding.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/bridge.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/bridge-300x225.png" alt="Revamped YaST interface for handling bridges" width="300" height="225" class="aligncenter size-medium wp-image-12077" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/bridge-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bridge-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bridge.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>This revamp includes also quite some usability improvements:</p>
+<ul>
+<li>&#8220;NONE&#8221; is shown instead of 0.0.0.0 for old bridge configuration.</li>
+<li>The bridge master is shown in the enslaved interface.</li>
+<li>The interfaces overview is updated after a bridge is modified.</li>
+</ul>
+<h3>Optimizing read of hosts file</h3>
+<p>It was reported that yast2-network was slow in system with a lot of entries in the <code>/etc/hosts</code> file. We took that as an opportunity to test the new profiler support in YaST. The profiler revealed the problem was in some slow calls to <a href="http://yastgithubio.readthedocs.io/en/latest/architecture/#system-configuration-repository-scr">SCR</a>, the layer traditionally used by YaST to interact with the underlying system&#8230; which sounded like another opportunity. This time an opportunity to expand the use of <a href="https://github.com/config-files-api/config_files_api">CFA</a> (the component we are developing to steady replace SCR) and its <a href="http://augeas.net/">Augeas</a> parser. Since Augeas already supports parsing of <code>/etc/hosts</code> files, it was quite straightforward to implement that into YaST&#8230; and the result is quite impressive.</p>
+<p>The time needed to execute the next command in a system containing a huge <code>/etc/hosts</code> with around 10,000 entries (quite an extreme case, we know) was reduced from 75 seconds to just 20.</p>
+<pre>
+yast2 lan list
+</pre>
+<p>As you can see in <a href="https://github.com/config-files-api/config_files_api/pull/10">this pull request</a>, we also improved CFA itself, greatly reducing the time needed for reading configuration files with Augeas.</p>
+<h3>That&#8217;s all&#8230; until next report</h3>
+<p>Once again, we must conclude the report telling that this was just a small summary of all the work done during the sprint and that we will be back in three weeks with the next report. Or maybe before, now that we are starting to get used to blog more often.</p>
+<p>In any case, see you soon and don&#8217;t forget to have a lot of fun!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/20/highlights-of-yast-development-sprint-26/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Proprietary AMD/ATI Catalyst fglrx 15.12 rpms released for LEAP 42.2</title>
+		<link>https://lizards.opensuse.org/2016/10/15/proprietary-amdati-catalyst-fglrx-15-12-rpms-released-for-leap-42-2/</link>
+		<comments>https://lizards.opensuse.org/2016/10/15/proprietary-amdati-catalyst-fglrx-15-12-rpms-released-for-leap-42-2/#comments</comments>
+		<pubDate>Sat, 15 Oct 2016 16:16:18 +0000</pubDate>
+		<dc:creator><![CDATA[Bruno Friedmann]]></dc:creator>
+				<category><![CDATA[GNOME]]></category>
+		<category><![CDATA[KDE]]></category>
+		<category><![CDATA[Kernel]]></category>
+		<category><![CDATA[42.2]]></category>
+		<category><![CDATA[amd]]></category>
+		<category><![CDATA[fglrx]]></category>
+		<category><![CDATA[xorg]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12052</guid>
+		<description><![CDATA[Warnings There’s no warranties the drivers will work, for you! If you are satisfied with the open-source radeon drivers, don’t risk to break your computer ! Still there will NEVER be a fglrx driver for recent kernel and xorg. So if one of those component change in Leap fglrx will be broken. Actual situation Since [&#8230;]]]></description>
+				<content:encoded><![CDATA[<h3>Warnings</h3>
+<p>There’s no warranties the drivers will work, for you!</p>
+<p>If you are satisfied with the open-source radeon drivers,<span style="color: #ff0000"> <b>don’t risk to break your computer !<br />
+</b></span></p>
+<p>Still there will NEVER be a fglrx driver for recent kernel and xorg. So if one of those component change in Leap fglrx will be broken.</p>
+<h3>Actual situation</h3>
+<p>Since last december, AMD doesn&#8217;t published any update about fglrx so the version is still the 15.12.302 published. A few days ago our beloved Leap release manager Ludwig ask me by email, if there will be an available drivers for Leap 42.2.</p>
+<p>Today, after hacking a bit the last Sebastian Siebert&#8217;s script I&#8217;ve been able to build the drivers for Leap 42.2 RC1, and the driver install fine, and xorg start on my HD5750 (but that&#8217;s all what I can tell).</p>
+<p>I will rebuild the driver once Leap 42.2 will hit its final stage.</p>
+<h3>Repository</h3>
+<pre>zypper ar -cfg -n FGLRX http://geeko.ioda.net/mirror/amd-fglrx/openSUSE_Leap_42.2/ FLGRX
+
+zypper -v refresh -f FGLRX
+
+zypper -v install fglrx64_amdcccle_SUSE422 fglrx64_core_SUSE422 fglrx64_graphics_SUSE422  fglrx64_opencl_SUSE422 fglrx64_xpic_SUSE422</pre>
+<h3>Future</h3>
+<p>AMD has stopped any development for FGLRX, so it is already considered obsolete. But on the other side they make a lot of effort to bring radeon and amdgpu (the free and open source driver) to a decent performance level.</p>
+<p>I don&#8217;t have that much usage anymore of my AMD gpu powered computer, and my HD5750 is now 8 years old already, so I can&#8217;t promise to be able to follow up with changes.</p>
+<h3>Cleanup</h3>
+<p>I removed all the obsoletes packages letting only the last one for each openSUSE version still available. Also the server has no more copy of openSUSE github artwork. If this missing to someone, don&#8217;t hesitate to ask.</p>
+<p>Have fun</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/15/proprietary-amdati-catalyst-fglrx-15-12-rpms-released-for-leap-42-2/feed/</wfw:commentRss>
+		<slash:comments>5</slash:comments>
+		</item>
+		<item>
+		<title>Reducing YaST rebuild time by 30%</title>
+		<link>https://lizards.opensuse.org/2016/10/11/reducing-yast-rebuild-time-by-30/</link>
+		<comments>https://lizards.opensuse.org/2016/10/11/reducing-yast-rebuild-time-by-30/#comments</comments>
+		<pubDate>Tue, 11 Oct 2016 13:51:10 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Build Service]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12030</guid>
+		<description><![CDATA[Here comes the YaST team again trying to flood your aggregator with blog post! Now it&#8217;s time for the story of how we reduced the critical path of the rebuild time of YaST RPM packages from 42min 2s to 29min 40s. Chapter 1: where to optimize Of course, the first step to start fixing something [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Here comes the YaST team again trying to flood your aggregator with blog post! Now it&#8217;s time for the story of how we reduced the critical path of the rebuild time of YaST RPM packages from 42min 2s to 29min 40s.</p>
+<h2>Chapter 1: where to optimize</h2>
+<p>Of course, the first step to start fixing something is finding out what exactly needs to be fixed. In our case, this breaks down into</p>
+<ol>
+<li>knowing the dependencies, and</li>
+<li>knowing the individual build times.</li>
+</ol>
+<h3>Dependencies</h3>
+<p>It is tempting to figure out the dependencies by yourself, by parsing the spec files. But it is hard to do right, and, more importantly, a reinvention of the wheel. The Build Service must know all this to be able to schedule the builds, and provides a convenient way to access it, with <code>osc dependson</code>:</p>
+<pre>
+$ osc dependson YaST:Head openSUSE_Factory x86_64
+[...]
+yast2-x11 :
+   yast2-devtools
+yast2-xml :
+   yast2-core
+   yast2-devtools
+yast2-ycp-ui-bindings :
+   libyui
+   yast2-core
+   yast2-devtools
+</pre>
+<h3>Individual build times</h3>
+<p>For each source package, the Build Service produces not only binary RPMs but also a <code>_statistics</code> file, available in the <a href="https://build.opensuse.org/package/statistics/YaST:Head/yast2-core?arch=x86_64&amp;repository=openSUSE_Factory">web UI</a> or via <code>osc getbinaries</code>. We were interested in the total build time, although the data was of limited use because packages can be built on machines with vastly different power and this information is not included.</p>
+<h2>Chapter 2: how to optimize</h2>
+<p>Once we knew which screws needed to be tightened, it was time to do it. Fortunately we had more than one tool for the job.</p>
+<h3>Stop using Autotools</h3>
+<p>Autotools (automake, autoconf and configure) took up a majority of the time needed for building YaST packages. Now that most of those packages are written in pure Ruby, we don&#8217;t need autotools there checking for portability problems that we don&#8217;t have. Autotools are a leftover from the times 15 years back when they were the only sensible option. We <a href="https://twitter.com/timmartin2/status/23365017839599616">have wiped them out</a> where possible and have been <a href="https://github.com/yast/yast-bootloader/commit/5fb46ea8046ea9863e5411ffe1394797e71dde1e">switching</a> to our own <a href="https://github.com/openSUSE/packaging_rake_tasks">set of Rake tasks</a>.</p>
+<h3>Stub the APIs used in tests</h3>
+<p>We run a mixture of unit and integration tests at RPM build time. The downside of this is that we pull in many of the run time dependencies. Fortunately Ruby is a dynamic language and makes it easy to replace interfaces by stubs. That enables us to cut those dependencies.</p>
+<p>
+In fact, we also have some Perl code, notably in yast2-users. Although the stubbing techniques across languages are messier than with pure ruby, they are still effective for our purposes.</p>
+<h3>Do not build specialized documentation</h3>
+<p>This one is simple: if the development documentation is only useful for people that will check out the git repo anyway, then leave it out from the RPM.</p>
+<h2>Appendix: the details</h2>
+<p>
+Enough of high-level explanations, we we promised you graphs, code and all kind of gory details, and a promise made is a debt unpaid. So there we go.</p>
+<h3>Dependency graphs</h3>
+<p>A picture is worth a thousand words. That&#8217;s why we came up with <a href="https://github.com/mvidner/rpm-build-dependencies">this small tool</a> to generate a graphical representation of the dependencies of the YaST packages. In the resulting graphs displayed below, a node is a source package in the build service, and an arrow means &#8220;needs for its build&#8221;. Redundant arrows are omitted (that is, we&#8217;ve erased an A→C if both A→B and B→C existed).</p>
+<p>
+We can see that the most prominent conclusion is that there is a large number of packages that depend on yast2, a collection of basic libraries.</p>
+<p>
+But on top of that, in the original graph there are 6 more layers, and the graph is not very dense there. After our fixes, there are only 4 layers that are more dense.</p>
+<p>Is worth mentioning that the &#8220;layer&#8221; concept only works if the packages take roughly the same time to build; it would not be helpful if there were huge variations. To get a more accurate picture, we should have generated a histogram of build times. But the graph was good enough in our scenario&#8230; and we had to stop the analysis at some point. <img src="https://s.w.org/images/core/emoji/2/72x72/1f642.png" alt="&#x1f642;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>
+The build dependency graph before our fixes:</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before-248x300.png" alt="YaST dependencies graph (before)" width="248" height="300" class="aligncenter size-medium wp-image-12033" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before-248x300.png 248w, https://lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before-768x928.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before-848x1024.png 848w, https://lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before.png 1600w" sizes="(max-width: 248px) 100vw, 248px" /></a></p>
+<p>The build dependency graph after our fixes:</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-184x300.png" alt="YaST dependencies graph (after)" width="184" height="300" class="aligncenter size-medium wp-image-11989" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-184x300.png 184w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-768x1255.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-627x1024.png 627w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after.png 1600w" sizes="(max-width: 184px) 100vw, 184px" /></a></p>
+<h3>Build statistics</h3>
+<p>If those graph are not geeky enough for you, here you are the detailed build statistics from the build service</p>
+<pre>
+&lt;buildstatistics&gt;
+  &lt;disk&gt;
+    &lt;usage&gt;
+      &lt;size unit="M"&gt;1118&lt;/size&gt;
+      &lt;io_requests&gt;15578&lt;/io_requests&gt;
+      &lt;io_sectors&gt;2156642&lt;/io_sectors&gt;
+    &lt;/usage&gt;
+  &lt;/disk&gt;
+  &lt;memory&gt;
+    &lt;usage&gt;      &lt;size unit="M"&gt;580&lt;/size&gt; &lt;/usage&gt;
+  &lt;/memory&gt;
+  &lt;times&gt;
+    &lt;total&gt;      &lt;time unit="s"&gt;756&lt;/time&gt; &lt;/total&gt;         &lt;!-- THIS --&gt;
+    &lt;preinstall&gt; &lt;time unit="s"&gt;8&lt;/time&gt;   &lt;/preinstall&gt;
+    &lt;install&gt;    &lt;time unit="s"&gt;72&lt;/time&gt;  &lt;/install&gt;
+    &lt;main&gt;       &lt;time unit="s"&gt;555&lt;/time&gt; &lt;/main&gt;
+    &lt;download&gt;   &lt;time unit="s"&gt;4&lt;/time&gt;   &lt;/download&gt;
+  &lt;/times&gt;
+  &lt;download&gt;
+    &lt;size unit="k"&gt;33564&lt;/size&gt;
+    &lt;binaries&gt;53&lt;/binaries&gt;
+    &lt;cachehits&gt;24&lt;/cachehits&gt;
+    &lt;preinstallimage&gt;preinstallimage.preinstallimage.tar.gz&lt;/preinstallimage&gt;
+  &lt;/download&gt;
+&lt;/buildstatistics&gt;
+</pre>
+<h2>Epilogue</h2>
+<p>This was definitely an interesting journey. We learned quite some  things. Specially we learned that there is still room for improvement, but most likely the time reduction will not pay off for the time invested implementing those improvements.</p>
+<p>We have to be realistic and keep working in other interesting stuff to fuel the next sprint report, coming next week!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/11/reducing-yast-rebuild-time-by-30/feed/</wfw:commentRss>
+		<slash:comments>3</slash:comments>
+		</item>
+		<item>
+		<title>Improving low-vision accessibility of the installer</title>
+		<link>https://lizards.opensuse.org/2016/10/07/improving-low-vision-accessibility-of-the-installer/</link>
+		<comments>https://lizards.opensuse.org/2016/10/07/improving-low-vision-accessibility-of-the-installer/#comments</comments>
+		<pubDate>Fri, 07 Oct 2016 08:25:36 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Accessibility]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[Usability]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12019</guid>
+		<description><![CDATA[In our latest report, we promised you would not have to wait another three weeks to hear (or read) from us. And here we are again, but not with any of the anticipated topics (build time reduction and Euruko 2016), but with a call for help in a topic that could really make a difference [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>In our <a href="https://lizards.opensuse.org/?p=11983">latest report</a>, we promised you would not have to wait another three weeks to hear (or read) from us. And here we are again, but not with any of the anticipated topics (build time reduction and Euruko 2016), but with a call for help in a topic that could really make a difference for (open)SUSE.
+</p>
+<p>
+Nowadays, YaST team is trying to fix a long-standing issue in the installer: <a href="https://bugzilla.suse.com/show_bug.cgi?id=780621">low-vision accessibility</a>. In the past, a user could get a high-contrast mode just pressing shift+F4 during installation. Unfortunately, that feature does not work anymore and, to be honest, changing to a high-contrast palette is not enough. Other adjustments, like setting better font sizes, should be taken into account.
+</p>
+<p>
+Another option is to use the textmode installation and set some obscure variable (<code>Y2NCURSES_COLOR_THEME</code>) to get the high-contrast mode. But it sounds like the opposite to <em>user friendly</em>.
+</p>
+<p>
+  Some days ago, the team fired up the <a href="https://lists.opensuse.org/opensuse-factory/2016-09/msg00593.html">discussion</a> in the opensuse-factory mailing list but we would like to reach as many people as we can to gather information and feedback about this topic. Getting some affected people involved in the process would be really awesome!
+</p>
+<p>For the time being we’re already working on some improvements:</p>
+<ul>
+<li>
+    Adding a Linuxrc option so the user can set the high-contrast mode from the very beginning.
+  </li>
+<li>
+    Fixing <a href="http://bugzilla.novell.com/show_bug.cgi?id=768112">shift+F4 support</a>.
+  </li>
+<li>
+    Improving the high-contrast mode appearance. Below you can see a screenshot of the work in progress.
+  </li>
+</ul>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/lowvision.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/lowvision-300x225.png" alt="First prototype of the new high contrast mode" width="300" height="225" class="aligncenter size-medium wp-image-12025" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/lowvision-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/lowvision-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/lowvision.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>
+  But we would like to hear from you. You can raise your voice in the already mentioned <a href="https://lists.opensuse.org/opensuse-factory/2016-09/msg00593.html">thread at the opensuse-factory mailing list</a> or leave a comment in the related <a href="https://github.com/libyui/libyui-qt/pull/60">pull request</a> at Github. If you prefer to have a chat, we&#8217;re also available on <a href="irc://irc.opensuse.org/yast">the #yast IRC channel</a> at Freenode&#8230; and we love to see people there. <img src="https://s.w.org/images/core/emoji/2/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" />
+</p>
+<p>
+Please, join us to make YaST even better!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/07/improving-low-vision-accessibility-of-the-installer/feed/</wfw:commentRss>
+		<slash:comments>2</slash:comments>
+		</item>
+		<item>
+		<title>Atualizando o Edison Intel no openSUSE</title>
+		<link>https://lizards.opensuse.org/2016/10/03/atualizando-o-edison-intel-no-opensuse/</link>
+		<comments>https://lizards.opensuse.org/2016/10/03/atualizando-o-edison-intel-no-opensuse/#respond</comments>
+		<pubDate>Mon, 03 Oct 2016 22:50:06 +0000</pubDate>
+		<dc:creator><![CDATA[Alessandro de Oliveira Faria]]></dc:creator>
+				<category><![CDATA[Programming]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12014</guid>
+		<description><![CDATA[Neste post, disponibilizo os passos efetuados para atualizar o firmware do meu Intel Edison na plataforma openSUSE. ATENÇÃO: Antes de iniciar deixo claro , que o leitor deste post é responsável por qualquer problema que venha a acontecer com o seu aparelho, logo: sendo de sua inteira responsabilidade e risco a utilização das instruções a [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p style="text-align: justify">Neste post, disponibilizo os passos efetuados para atualizar o firmware do meu Intel Edison na plataforma openSUSE.</p>
+<p><span style="color: #ff0000"><strong>ATENÇÃO: Antes de iniciar deixo claro , que o leitor deste post é responsável por qualquer problema que venha a acontecer com o seu aparelho, logo: sendo de sua inteira responsabilidade e risco a utilização das instruções a seguir.</strong></span></p>
+<p>Primeiramente instale o pacote</p>
+<pre>
+# zypper addrepo http://download.opensuse.org/repositories/home:cabelo:desktop/openSUSE_Leap_42.1/home:cabelo:desktop.repo
+# zypper refresh</strong>
+# zypper install dfu-util
+</pre>
+<p>Faça o Download da ultima versão do firmware em https://software.intel.com/pt-br/iot/hardware/edison/downloads</p>
+<p>Posicione a chave <strong>SW1</strong> próxima ao conector micro USB de acordo com a figura abaixo e plugue os 2 cabos USB:</p>
+<p><img class="alignnone size-full wp-image-4211" src="https://cabelovivaolinux.files.wordpress.com/2016/03/intel-edison-setup-1.png" alt="intel-edison-setup-1" width="1027" height="367" /></p>
+<p>E logo a seguir descompacte o arquivo recém baixado e execute o comando ./flashall.sh</p>
+<p><img class="alignnone size-full wp-image-4204" src="https://cabelovivaolinux.files.wordpress.com/2016/03/yocto02.png" alt="yocto02" width="1030" height="460" /></p>
+<p>Se executar o comando sudo screen /dev/ttyUSB0 115200, teremos a seguinte saida no console:</p>
+<p><strong>Starting Reboot&#8230;</strong></p>
+<p><strong>******************************</strong><br />
+<strong> PSH KERNEL VERSION: b0182727</strong><br />
+<strong> WR: 20104000</strong><br />
+<strong> ******************************</strong></p>
+<p><strong>SCU IPC: 0x800000d0 0xfffce92c</strong></p>
+<p><strong>PSH miaHOB version: TNG.B0.VVBD.0000000c</strong></p>
+<p><strong>microkernel built 23:15:13 Apr 24 2014</strong></p>
+<p><strong>******* PSH loader *******</strong><br />
+<strong> PCM page cache size = 192 KB</strong><br />
+<strong> Cache Constraint = 0 Pages</strong><br />
+<strong> Arming IPC driver ..</strong><br />
+<strong> Adding page store pool ..</strong><br />
+<strong> PagestoreAddr(IMR Start Address) = 0x04899000</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong></p>
+<p><strong>U-Boot 2014.04 (Aug 20 2014 &#8211; 16:08:32)</strong></p>
+<p><strong>Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning already done&#8230;</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0x3756edb6</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0x3756edb6</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0x6ad212b0</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xe511e42b</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xe511e42b</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> resetting &#8230;</strong></p>
+<p><strong>******************************</strong><br />
+<strong> PSH KERNEL VERSION: b0182b2b</strong><br />
+<strong> WR: 20104000</strong><br />
+<strong> ******************************</strong><br />
+<strong> SCU IPC: 0x800000d0 0xfffce92c</strong><br />
+<strong> PSH miaHOB version: TNG.B0.VVBD.0000000c</strong><br />
+<strong> microkernel built 11:24:08 Feb 5 2015</strong></p>
+<p><strong>******* PSH loader *******</strong><br />
+<strong> PCM page cache size = 192 KB</strong><br />
+<strong> Cache Constraint = 0 Pages</strong><br />
+<strong> Arming IPC driver ..</strong><br />
+<strong> Adding page store pool ..</strong><br />
+<strong> PagestoreAddr(IMR Start Address) = 0x04899000</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong><br />
+<strong> U-Boot 2014.04 (Jun 19 2015 &#8211; 12:05:55)</strong><br />
+<strong> Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Writing to MMC(0)&#8230; done</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning using GPT</strong><br />
+<strong> Writing GPT: success!</strong><br />
+<strong> Saving Environment to MMC&#8230;</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xb98db2f8</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong><br />
+<strong> U-Boot 2014.04 (Jun 19 2015 &#8211; 12:05:55)</strong><br />
+<strong> Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Writing to MMC(0)&#8230; done</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning using GPT</strong><br />
+<strong> Writing GPT: success!</strong><br />
+<strong> Saving Environment to MMC&#8230;</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xb98db2f8</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong></p>
+<p><strong>U-Boot 2014.04 (Jun 19 2015 &#8211; 12:05:55)</strong></p>
+<p><strong>Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Writing to MMC(0)&#8230; done</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning using GPT</strong><br />
+<strong> Writing GPT: success!</strong><br />
+<strong> Saving Environment to MMC&#8230;</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xb98db2f8</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> ######################################################################################</strong></p>
+<p><strong>******* PSH loader *******</strong><br />
+<strong> PCM page cache size = 192 KB</strong><br />
+<strong> Cache Constraint = 0 Pages</strong><br />
+<strong> Arming IPC driver ..</strong><br />
+<strong> Adding page store pool ..</strong><br />
+<strong> PagestoreAddr(IMR Start Address) = 0x04899000</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong><br />
+<strong> U-Boot 2014.04 (Jun 19 2015 &#8211; 12:05:55)</strong><br />
+<strong> Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Writing to MMC(0)&#8230; done</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning using GPT</strong><br />
+<strong> Writing GPT: success!</strong><br />
+<strong> Saving Environment to MMC&#8230;</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+DFU complete CRC32: 0xb98db2f8<br />
+DOWNLOAD &#8230; OK<br />
+Ctrl+C to exit &#8230;<br />
+##############################################################################################</p>
+<p>Se tudo funcionou corretamente, teremos a seguinte tela:</p>
+<p><img class="alignnone size-full wp-image-4215" src="https://cabelovivaolinux.files.wordpress.com/2016/03/yocto03.png" alt="yocto03" width="1160" height="741" /></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/03/atualizando-o-edison-intel-no-opensuse/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+	</channel>
+</rss>

--- a/jekyll/feed1.xml
+++ b/jekyll/feed1.xml
@@ -1,0 +1,893 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	>
+
+<channel>
+	<title>openSUSE Lizards</title>
+	<atom:link href="https://lizards.opensuse.org/feed/" rel="self" type="application/rss+xml" />
+	<link>https://lizards.opensuse.org</link>
+	<description>Blogs and Ramblings of the openSUSE Members</description>
+	<lastBuildDate>Wed, 23 Nov 2016 16:47:54 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>hourly</sy:updatePeriod>
+	<sy:updateFrequency>1</sy:updateFrequency>
+	<generator>https://wordpress.org/?v=4.6.1</generator>
+	<item>
+		<title>YaST Team visits Euruko 2016</title>
+		<link>https://lizards.opensuse.org/2016/11/23/yast-team-visits-euruko-2016/</link>
+		<comments>https://lizards.opensuse.org/2016/11/23/yast-team-visits-euruko-2016/#respond</comments>
+		<pubDate>Wed, 23 Nov 2016 16:47:54 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Events]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12116</guid>
+		<description><![CDATA[As promised in previous posts, we want to share with you our experience and views from this year annual Ruby conference Euruko. Maybe &#8220;our&#8221; is too much to say, since we only sent one developer there. So to be precise, these are Josef Reidinger&#8217;s experience and views on the conference. This year Euruko took place [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>As promised in previous posts, we want to share with you our experience and views from this year annual Ruby conference <a href="http://euruko2016.org">Euruko</a>. Maybe &#8220;our&#8221; is too much to say, since we only sent one developer there. So to be precise, these are Josef Reidinger&#8217;s experience and views on the conference.</p>
+<p>This year Euruko took place in Sofia, capital of Bulgaria. It turned out to be a great conference place. Public transport works very well, everyone speak English and even when it uses Cyrilic alphabet, almost everything is written also in Latin one.</p>
+<p>That being said, let&#8217;s talk about the conference content. Fortunately all the presentations were recorded so you can <a href="https://www.youtube.com/channel/UChGs1td4ViQFqT0jlvkyUJg">watch them yourself</a>. But since it would be quite some hours of video to go through, we have reviewed some presentations for you including access to the corresponding videos.</p>
+<h3>Highlights</h3>
+<p>Let&#8217;s start with the three presentation Josef specially recommend to watch.</p>
+<p><b>Keynote by Matz</b></p>
+<p>He speaks about how Ruby 3 will probably look in distant future. With &#8220;distant future&#8221; meaning &#8220;for sure not in next two years&#8221;. If you cannot wait, it&#8217;s worth mentioning that Ruby 2.4 will be released on December.</p>
+<p>Ruby 3 will use guild membership concurrency model. The most interesting part of the talk is digging into rationale of typed versus non-typed languages and what can be the Ruby future in that regard.</p>
+<p><iframe width="500" height="281" src="https://www.youtube.com/embed/8aHmArEq4y0?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
+<p><b>Rules, Laws and Gently Guidelines by Andrew Radev</b></p>
+<p>Interesting view about common design principles, common mistakes when applying them and looking to them from different angles. Also explaining how to handle situations in which several design principles seem to contradict each other.</p>
+<p><iframe width="500" height="281" src="https://www.youtube.com/embed/BDXQ4pcbEBA?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
+<p><b>Elixir by Jose Valim</b></p>
+<p>Interesting intro to Elixir language. What it is, why it make sense to use it and what are its benefits. Josef&#8217;s impression was that Elixir&#8217;s idea is similar to isolated micro-services communicating via messages, with nice introspection and scalability.</p>
+<p>But we have more team members with something to say about Elixir. Like Imobach, who has been playing with Elixir (and <a href="http://www.phoenixframework.org/">Phoenix</a>) for some time now. And Imobach really likes Elixir, so he would like to add some more bits of information for those who are interested.</p>
+<p>For example, he would like to highlight that Elixir uses BEAM, the Erlang virtual machine, so great support for concurrency is backed in the platform. Concurrency sits on the concept of Erlang processes and it&#8217;s pretty common to use them for all kind of tasks (from computation to storing state, etc.). Imobach would like to encourage all developers out there to take a look to <a href="https://en.wikipedia.org/wiki/Open_Telecom_Platform">OTP (Open Telecom Platform)</a>. Who needs micro-services at all? </p>
+<p>Last but not least, take into account that Elixir is a functional language, so if you have an object-oriented mindset (like most Ruby developers) it will take some time to wrap your head around it.</p>
+<p><iframe width="500" height="281" src="https://www.youtube.com/embed/xhwnHovnq_0?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
+<h3>Other presentations</h3>
+<p><b>Little Snippets by Xavier Noria</b></p>
+<p>Summary of common inefficiency in small snippets. Small things that matter, although most of them should be already known by the average Ruby developer. (<a href="https://www.youtube.com/watch?v=mC9TyVeER_8">Video</a>)</p>
+<p>Since we mention the topic, some YaST team members has found <a href="https://github.com/JuanitoFatas/fast-ruby">this cheat sheet</a> by Juanito Fatas about Ruby optimization to be quite useful.</p>
+<p><b>Rails + Kafka by Terence Lee</b></p>
+<p>Apache Kafka is yet another messaging system. This talk did not manage to convince Josef to use it, but maybe it makes sense in some scenarios like HPC or HA. (<a href="https://www.youtube.com/watch?v=yl3JmF3n2bQ">Video</a>)</p>
+<p><b>Graphql on Rails by Marc-Andre Giroux</b></p>
+<p>The typical REST setup is sometimes not scalable enough due to the excess of endpoints. The Graphql language is designed to specify what resources are needed from a server in a single query. The result is returned as JSON and the request specification looks also similar to JSON. Caching is done on client side. Interesting for web stuff and already used by Facebook, Shopify and others. (<a href="https://www.youtube.com/watch?v=_V96jduEvjY">Video</a>)</p>
+<p><b>Evolution of engineering on call team by Grace Chang</b></p>
+<p>How to maintain services, how to scale when the grow, preventing burnout and so on. Specially interesting for us since there are many similarities with YaST maintenance. Maybe the end of the talk is a bit theoretic and idealistic. (<a href="https://www.youtube.com/watch?v=u_7wrPXaSto">Video</a>)</p>
+<p><b>Sprockets by Rafael Franca</b></p>
+<p>Not specially interesting intro to assets generation used by Rails. People doing some assets generation with Rails would most likely already know all the content. (<a href="https://www.youtube.com/watch?v=rbM_1wRVfeI">Video</a>)</p>
+<p><b>Contribute to Ruby core by Hiroshi Shibata</b></p>
+<p>Presentation about Ruby core development infrastructure, rules, etc. Certainly not the best talk ever. (<a href="https://www.youtube.com/watch?v=IRfsakcZJKw">Video</a>)</p>
+<p><b>Consequences of insightful algorithms by Carina C. Zona</b></p>
+<p>Interesting presentation about conflicts between algorithms and real humans, especially with data-mining. Unfortunately, the second half turned to be too emotional and not technical enough for Josef&#8217;s taste :). (<a href="https://www.youtube.com/watch?v=bp4yFKw_1QM">Video</a>)</p>
+<p><b>Viewing Ruby Blossom &#8211; Hamani by Anton Davydov</b></p>
+<p>Introduction to yet another Ruby web framework. Not that interesting for us. (<a href="https://www.youtube.com/watch?v=3L6I4UoK8xM">Video</a>)</p>
+<p><b>A Year of Ruby, Together by Andre Arko</b></p>
+<p>Introduction on how the open source community infrastructure behind Rubygems and Bundler is ran. How they get money to improve stuff, how they maintain their servers&#8230; Good talk about hard times keeping open source infrastructure alive. Interesting talk for any open source project. (<a href="https://www.youtube.com/watch?v=SJddsEfvcW8">Video</a>)</p>
+<p><b>What I Have Learned from Organizing Remote Internship for Ruby Developers by Ivan Nemytchenko</b></p>
+<p>Talk describing an attempt to scale internship for a lot of students. Josef had a small chat with the author about Google Summer of Code after the presentation. He looked interested. (<a href="https://www.youtube.com/watch?v=H-K0ZKOclBU">Video</a>)</p>
+<p><b>The Illusion of Stable APIs by Nick Sutterer</b></p>
+<p>Not Josef&#8217;s cup of tea. The presenter probably went a little bit too far trying to be funny all the time. The core of the presentation was about three examples of API that needed to be changed &#8220;just&#8221; because the rest of the world changed. So the whole presentation can be shortened to one sentence &#8211; your API will only remain static if the world remains static. (<a href="https://www.youtube.com/watch?v=mvHwTtsIH8g">Video</a>)</p>
+<h3>Conclusion</h3>
+<p>That was all from Sofia. See you again in approximately one week, just in time for the report of our 28th Scrum sprint.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/11/23/yast-team-visits-euruko-2016/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of YaST development sprint 27</title>
+		<link>https://lizards.opensuse.org/2016/11/10/highlights-of-yast-development-sprint-27/</link>
+		<comments>https://lizards.opensuse.org/2016/11/10/highlights-of-yast-development-sprint-27/#comments</comments>
+		<pubDate>Thu, 10 Nov 2016 11:17:57 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Base System]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12095</guid>
+		<description><![CDATA[Another three weeks of development come to an end&#8230; and our usual report starts. Take a look to what we have been cooking. Read-only proposal modules This week, during SUSECon 2016, SUSE announced an exciting upcoming new product. SUSE CASP &#8211; a Kubernetes based Container As a Service Platform. That has, of course, some implications [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Another three weeks of development come to an end&#8230; and our usual report starts. Take a look to what we have been cooking. </p>
+<h3>Read-only proposal modules</h3>
+<p>This week, during <a href="http://www.susecon.com/">SUSECon 2016</a>, SUSE announced an exciting upcoming new product. SUSE CASP &#8211; a <a href="http://kubernetes.io/">Kubernetes</a> based Container As a Service Platform.</p>
+<p>That has, of course, some implications for the installer, like the need of some products (like CASP) to specify a fixed configuration for some subsystems. For example, an established selection of packages. The user should not be allowed to change those fixed configurations during installation.</p>
+<p>We have implemented a possibility to mark some modules in the installation proposal as read-only. These read-only modules then cannot be started from the installer and therefore their configuration is kept at the default initial state.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/11/readonly.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/11/readonly-300x225.png" alt="Software and firewall proposals as read-only" width="300" height="225" class="aligncenter size-medium wp-image-12099" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/11/readonly-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/11/readonly-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/11/readonly.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>In this sprint we have implemented a basic support in the proposal framework, in the future we could improve the respective proposal modules to better handle the read-only mode.</p>
+<h3>Per product Btrfs subvolumes handling</h3>
+<p>The ability to have read-only proposals is not the only improvement we have introduced in YaST to make SUSE CASP possible.</p>
+<p>When Btrfs is used during the installation, YaST2 proposes a list of subvolumes to create. Unfortunatelly, that list is hard-coded and it&#8217;s the same for every (open)SUSE product&#8230; until now.</p>
+<p>Starting on yast2-storage 3.1.103.1, a list of subvolumes can be defined in the product&#8217;s control file along with additional options (check out <a href="https://github.com/yast/skelcd-control-SLES/blob/master/control/control.SLES.xml#L190">SLES</a> and <a href="https://github.com/yast/skelcd-control-openSUSE/blob/master/control/control.openSUSE.xml#L297">openSUSE</a> examples to learn more).</p>
+<pre>
+&lt;subvolumes config:type="list"&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;boot/grub2/i386-pc&lt;/path&gt;
+    &lt;archs&gt;i386,x86_64&lt;/archs&gt;
+  &lt;/subvolume&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;home&lt;/path&gt;
+  &lt;/subvolume&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;opt&lt;/path&gt;
+  &lt;/subvolume&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;var/lib/libvirt/images&lt;/path&gt;
+    &lt;copy_on_write config:type="boolean"&gt;false&lt;/copy_on_write&gt;
+  &lt;/subvolume&gt;
+&lt;/subvolumes&gt;
+</pre>
+<p>This specification supports:</p>
+<ul>
+<li>Disabling copy-on-write for a given subvolume (it&#8217;s enabled by default).</li>
+<li>Enabling the creation of a subvolume only for a set of architectures.</li>
+</ul>
+<h3>Improved AutoYaST Btrfs subvolumes handling</h3>
+<p>AutoYaST Btrfs subvolumes handling has been also improved. Using almost the same syntax as for product control files, you can disable the <code>CoW</code> behavior for a given subvolume.</p>
+<p>Of course, if you don&#8217;t need such a feature, you won&#8217;t need to adapt your profiles to the new syntax as it&#8217;s backward compatible. You can also mix both of them:</p>
+<pre>
+&lt;subvolumes config:type="list"&gt;
+  &lt;subvolume&gt;home&lt;/subvolume&gt;
+  &lt;subvolume&gt;
+    &lt;path&gt;var/lib/libvirt/images&lt;/path&gt;
+    &lt;copy_on_write config:type="boolean"&gt;false&lt;/copy_on_write&gt;
+  &lt;/subvolume&gt;
+&lt;/subvolumes&gt;
+</pre>
+<p>On the other hand, if you&#8217;re running SLES, you&#8217;ll know that a subvolume called <code>@</code> is used as the default Btrfs subvolume. Now is possible to turn-off such behavior in the profile&#8217;s general section.</p>
+<pre>
+&lt;general&gt;
+  &lt;btrfs_set_subvolume_default_name config:type="boolean"&gt;false&lt;/btrfs_set_subvolume_default_name&gt;
+&lt;/general&gt;
+</pre>
+<h3>Disable installer self-update by default</h3>
+<p>We have talked many times in this blog about the new self-update functionality for the installer. As expected, this functionality will debut in SLE-12-SP2 but with a small change in the original plan. In order to ensure maximum consistency in the behavior of SLE-12-SP1 and SP2 installers, the self-update functionality will be disabled by default. Not a big deal, since enabling it to get the latest fixes will be just a matter of adding a boot option in the initial installation screen.</p>
+<h3>Storage reimplementation: adapted EFI proposal in yast2-bootloader</h3>
+<p>The previous report about the status of the storage stack reimplementation finished with the following cliffhanger &#8220;<i>we have in place all the ingredients to cook an installable ISO</i>&#8220;. So, as expected, we worked during this sprint in adapting the bootloader proposal to the new storage layer. As you can see in the following screenshot, we succeeded and the installer can already propose a valid grub2 setup to boot an EFI system.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi-300x225.png" alt="EFI proposal with the storage-ng ISO" width="300" height="225" class="aligncenter size-medium wp-image-12100" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/11/grub2efi.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Does that mean that the testing ISO for the new storage stack is already fully installable? Unfortunately not. Why not, you ask? The reason is, in fact, kind of fun.</p>
+<p>The current partitioning proposal only works with MS-DOS style partition tables because we wanted to address the most complicated case first. On the other hand, we intentionally restricted the adaptation of the bootloader proposal to the EFI scenario. And you know what? We found out that combination (MS-DOS partition table + EFI) <a href="https://bugzilla.suse.com/show_bug.cgi?id=1008289">does not currently work</a> in Tumbleweed, so it neither does in our Tumbleweed-based testing ISO.</p>
+<p>We will work during the following sprint to support another scenario. And hopefully we will not choose again an unsupported or broken one. <img src="https://s.w.org/images/core/emoji/2/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<h3>Letting libYUI run free: first visible steps</h3>
+<p>As you know, YaST has both a graphical and a textual interface. They run on the same code thanks to an abstraction layer called LibYUI. Originally it served YaST only, but over time other projects started using it, notably the admin panel in Mageia. Moreover, the developers of those projects started to contribute fixes and improvements to LibYUI&#8230; faster than we can cope with.</p>
+<p>Recently we decided to give the people outside the YaST team more power in the LibYUI project. To make that possible ensuring it does not affect YaST stability, we have been enabling more continuous integration tests.</p>
+<p>As a first fruit of the revamped collaboration, we have merged a fix contributed by Angelo Naselli of Mageia regarding selection of tree items. As soon as we complete our continuous integration setup (of course we will keep you informed), more fixes and improvements will come for sure.</p>
+<h3>More bug squashing and bug paleontology</h3>
+<p>In the <a href="https://lizards.opensuse.org/2016/10/20/highlights-of-yast-development-sprint-26/">previous report</a> we presented our new effort to integrate the fix of low-priority bugs into the Scrum process. During this sprint we refined the idea a little bit more, distinguishing two separate concepts (each of them with its own <a href="https://www.scrumalliance.org/community/articles/2007/march/glossary-of-scrum-terms#1130">PBI</a>) &#8211; fixing of existing bugs and closing of too old ones.</p>
+<p>The first one doesn&#8217;t need much explanation. We managed to fix around 25 non-critical bugs in YaST and if you are using Tumbleweed you are probably already benefiting from the result.</p>
+<p>The second task was not exactly about fixing bugs present in the software, but about cleaning bugzilla from bug reports that were simply too old to be relevant any more. Like bugs affecting very old versions of openSUSE that cannot be reproduced in openSUSE 13.2 or Leap. We must be realistic about releases that are already out of support and the limited human resources we have. We closed around 80 of those ancient bugs.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/11/no_country_for_old_bugs.jpg"><img src="//lizards.opensuse.org/wp-content/uploads/2016/11/no_country_for_old_bugs-300x169.jpg" alt="no_country_for_old_bugs" width="300" height="169" class="aligncenter size-medium wp-image-12105" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/11/no_country_for_old_bugs-300x169.jpg 300w, https://lizards.opensuse.org/wp-content/uploads/2016/11/no_country_for_old_bugs.jpg 569w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>So overall, we cleaned up around one hundred bugs from our queue. Still a long way to have a bug-free YaST, but undoubtedly a step in the right direction. </p>
+<h3>More coming</h3>
+<p>We are already working in the next sprint that will hopefully bring several new improvements for CASP, quite relevant progress in the storage reimplementation, several usability improvements, some bugfixes and even some news about this blog.</p>
+<p>To make sure you don&#8217;t get bored while waiting we are also planning to finally publish the report about our visit to <a href="http://euruko2016.org/">Euruko 2016</a>.</p>
+<p>Stay tuned!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/11/10/highlights-of-yast-development-sprint-27/feed/</wfw:commentRss>
+		<slash:comments>4</slash:comments>
+		</item>
+		<item>
+		<title>Basic Nextcloud installation on openSUSE Leap</title>
+		<link>https://lizards.opensuse.org/2016/10/28/nextcloud-installation-on-opensuse-leap/</link>
+		<comments>https://lizards.opensuse.org/2016/10/28/nextcloud-installation-on-opensuse-leap/#respond</comments>
+		<pubDate>Fri, 28 Oct 2016 15:09:09 +0000</pubDate>
+		<dc:creator><![CDATA[Efstathios Iosifidis]]></dc:creator>
+				<category><![CDATA[Apache]]></category>
+		<category><![CDATA[Documentation]]></category>
+		<category><![CDATA[Server]]></category>
+		<category><![CDATA[42.1]]></category>
+		<category><![CDATA[cloud]]></category>
+		<category><![CDATA[Leap]]></category>
+		<category><![CDATA[nextcloud]]></category>
+		<category><![CDATA[openSUSE]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12089</guid>
+		<description><![CDATA[I see the official documentation has full tutorial for RHEL 6 or CentOS 6 and RHEL 7 or CentOS 7. The main documentation covers Ubuntu 14.04 LTS openSUSE already has the Nextcloud client packaged in Tumbelweed and the Server is in the PHP extra repo! Personally, I prefer to install eveything from official repository, so [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p><img src="https://en.opensuse.org/images/0/0f/Nextcloud.png" alt="Nextcloud Logo" width="40%" height="40%" /></p>
+<p>I see the official documentation has full tutorial for <a href="https://docs.nextcloud.com/server/10/admin_manual/installation/php_54_installation.html" target="1">RHEL 6 or CentOS 6</a> and <a href="https://docs.nextcloud.com/server/10/admin_manual/installation/php_55_installation.html" target="1">RHEL 7 or CentOS 7</a>. The main documentation covers <a href="https://docs.nextcloud.com/server/10/admin_manual/installation/source_installation.html" target="1">Ubuntu 14.04 LTS</a></p>
+<p>openSUSE already has the <a href="https://software.opensuse.org/search?utf8=%E2%9C%93&amp;q=nextcloud&amp;search_devel=false&amp;search_unsupported=false&amp;baseproject=openSUSE%3AFactory" target="1">Nextcloud client packaged in Tumbelweed and the Server is in the PHP extra repo!</a> Personally, I prefer to install eveything from official repository, so when an update is available, I can have it without a glitch. This tutorial describes how to install Nextcloud using command line. I followed the official documentation of <a href="https://docs.nextcloud.com/server/10/admin_manual/installation/source_installation.html" target="1">Ubuntu 14.04 LTS installation</a>.</p>
+<p>Why choose <a href="https://en.opensuse.org/Portal:Leap" target="1">openSUSE Leap</a>? openSUSE Leap is a brand new way of building openSUSE and is new type of hybrid Linux distribution. Leap uses source from <a href="https://www.suse.com/promo/sle/" target="1">SUSE Linux Enterprise (SLE)</a>, which gives Leap a level of stability unmatched by other Linux distributions, and combines that with community developments to give users, developers and sysadmins the best stable Linux experience available. Contributor and enterprise efforts for Leap bridge a gap between matured packages and newer packages found in openSUSE’s other distribution Tumbleweed. You can download openSUSE Leap from the site <a href="https://software.opensuse.org/" target="1">https://software.opensuse.org/</a>.<br />
+<span id="more-12089"></span><br />
+Make sure that ssh (sshd) is enabled and also the firewall either is disabled or <a href="https://en.opensuse.org/SuSEfirewall2" target="1">make an exception to the apache and ssh services</a>. You can also set a static IP (<a href="http://eiosifidis.blogspot.gr/2015/05/set-static-ip-on-your-opensuse-raspberry-pi.html" target="1">check out how</a>).</p>
+<p>First of all, let&#8217;s install the required and recommended modules for a typical Nextcloud installation, using Apache and MariaDB, by issuing the following commands in a terminal:</p>
+<div class="code">zypper in apache2 mariadb apache2-mod_php5 php5-gd php5-json php5-fpm php5-mysql php5-curl php5-intl php5-mcrypt php5-zip php5-mbstring php5-zlib</div>
+<p><b>Create Database (optional since it&#8217;ll create eveything automatically)</b>Next step, create a database. First of all start the service.</p>
+<div class="code">systemctl start mysql.service<br />
+systemctl enable mysql.service</div>
+<p>The root password is empty by default. That means that you can press enter and you can use your root user. That&#8217;s not safe at all. So you can set a password using the command:</p>
+<div class="code">mysqladmin -u root password newpass</div>
+<p>Where newpass is the password you want.</p>
+<p>Now you set the root password, create the database.</p>
+<blockquote><p>mysql -u root -p<br />
+#you&#8217;ll be asked for your root passwordCREATE DATABASE nextcloudb;</p>
+<p>GRANT ALL ON nextcloudb.* TO ncuser@localhost IDENTIFIED BY &#8216;dbpass&#8217;;</p></blockquote>
+<p>Database user: <b>ncuser</b><br />
+Database name: <b>nextcloudb</b><br />
+Database user password: <b>dbpass</b></p>
+<p>You can change the above information accordingly.</p>
+<p><b>PHP changes</b><br />
+Now you should edit the php.ini file.</p>
+<blockquote><p>nano /etc/php5/apache2/php.ini</p></blockquote>
+<p>change the values</p>
+<blockquote><p>post_max_size = 50G<br />
+upload_max_filesize = 25G<br />
+max_file_uploads = 200<br />
+max_input_time = 3600<br />
+max_execution_time = 3600<br />
+session.gc_maxlifetime = 3600<br />
+memory_limit = 512M</p></blockquote>
+<p>and finally enable the extensions.</p>
+<blockquote><p>extension=php_gd2.dll<br />
+extension=php_mbstring.dll</p></blockquote>
+<p><b>Apache Configuration</b><br />
+You should enable some modules. Some might be already enabled.</p>
+<blockquote><p>a2enmod php5<br />
+a2enmod rewrite<br />
+a2enmod headers<br />
+a2enmod env<br />
+a2enmod dir<br />
+a2enmod mime</p></blockquote>
+<p>Now start the apache service.</p>
+<blockquote><p>systemctl start apache2.service<br />
+systemctl enable apache2.service</p></blockquote>
+<p><b>Install Nextcloud from source code (option 1, preferable)</b><br />
+Before the installation, create the data folder and give the right permissions (preferably outside the server directory for security reasons). I created a directory in the <i>/mnt</i> directory. You can mount a USB disk, add it to fstab and save your data there. The commands are:</p>
+<blockquote><p>mkdir /mnt/nextcloud_data<br />
+chmod -R 0770 /mnt/nextcloud_data<br />
+chown wwwrun /mnt/nextcloud_data</p></blockquote>
+<p>Now download Nextcloud (find the latest version at <a href="https://nextcloud.com/install/" target="1">https://nextcloud.com/install/</a>). Then unzip and move the folder to the server directory.</p>
+<blockquote><p>wget https://download.nextcloud.com/server/releases/nextcloud-10.0.0.zip<br />
+unzip nextcloud-10.0.0.zip<br />
+cp -r netcloud /srv/www/htdocs<br />
+chown -R wwwrun /srv/www/htdocs/nextcloud/</p></blockquote>
+<p>Make sure that everything is OK and then delete the folder nextcloud and nextcloud-10.0.0.zip from the root (user) directory.</p>
+<p>Now open your browser to the server IP/nextcloud</p>
+<p><a href="https://dl.dropboxusercontent.com/u/20413076/nextcloud/opensuse/nextcloud_install.png" target="1"><img src="https://dl.dropboxusercontent.com/u/20413076/nextcloud/opensuse/nextcloud_install.png" width="80%" height="80%" /></a>Set your administrator username and password.<br />
+Your data directory is: /mnt/nextcloud_data<br />
+Regarding database, use the following.<br />
+Database user: <b>ncuser</b><br />
+Database name: <b>nextcloudb</b><br />
+Database user password: <b>dbpass</b></p>
+<p>Wait until it ends the installation. The page you&#8217;ll see is the following.</p>
+<p><a href="https://dl.dropboxusercontent.com/u/20413076/nextcloud/opensuse/nextcloud_first_login.png" target="1"><img src="https://dl.dropboxusercontent.com/u/20413076/nextcloud/opensuse/nextcloud_first_login.png" width="80%" height="80%" /></a></p>
+<p><b>Install Nextcloud using the respository (option 2)</b></p>
+<p>If you want to have automatic updates of your Nextcloud instance when there&#8217;s a new version, you can add the repository. There are packages available for openSUSE Leap 42.1, 42.2 and Tumbleweed (we recommend openSUSE Leap 42.1). You should be an administrator, so you can install Nextloud on your server.</p>
+<p>1. Add the Nextcloud repository.<br />
+<strong>openSUSE_Leap_42.2</strong></p>
+<blockquote><p>zypper ar http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Leap_42.2/ Nextcloud</p></blockquote>
+<p><strong>openSUSE_Leap_42.1</strong></p>
+<blockquote><p>zypper ar http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Leap_42.1/ Nextcloud</p></blockquote>
+<p><strong>openSUSE_Leap_Tumbleweed</strong></p>
+<blockquote><p>zypper ar http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/ Nextcloud</p></blockquote>
+<p>2. Refresh your repositories</p>
+<blockquote><p>zypper refresh</p></blockquote>
+<p>3. Install Nextcloud (be careful you have to install LAMP first and change permissions of the files).</p>
+<blockquote><p>zypper install nextcloud</p></blockquote>
+<p>4. Open http://serverIP/nextcloud to install your instance (admin user account). Be careful to create another folder with the proper permissions for your data (as described).</p>
+<p>5. Login and use Nextloud.</p>
+<p>For more information about Nextcloud on openSUSE, check <a href="https://en.opensuse.org/SDB:Nextcloud" target="_blank">openSUSE wiki</a>.</p>
+<p>For any changes, check the <a href="https://github.com/iosifidis/nextcloud-opensuse-leap" target="1">github page</a>.</p>
+<p>For more configuration, you can follow the <a href="https://docs.nextcloud.com/server/10/admin_manual/contents.html" target="1">official documentation</a>. That was the basic installation on openSUSE Leap.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/28/nextcloud-installation-on-opensuse-leap/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of YaST development sprint 26</title>
+		<link>https://lizards.opensuse.org/2016/10/20/highlights-of-yast-development-sprint-26/</link>
+		<comments>https://lizards.opensuse.org/2016/10/20/highlights-of-yast-development-sprint-26/#comments</comments>
+		<pubDate>Thu, 20 Oct 2016 12:36:54 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Localization]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[Usability]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12055</guid>
+		<description><![CDATA[We did our best to keep you entertained during this development sprint with a couple of blog posts ([1] and [2]). But now the sprint is over and it&#8217;s time for a new report. Squashing low priority bugs One of the main reasons to adopt Scrum was to ensure we make a good use of [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>We did our best to keep you entertained during this development sprint with a couple of blog posts (<a href="https://lizards.opensuse.org/?p=12019">[1]</a> and <a href="https://lizards.opensuse.org/?p=12030">[2]</a>). But now the sprint is over and it&#8217;s time for a new report.</p>
+<h3>Squashing low priority bugs</h3>
+<p>One of the main reasons to adopt Scrum was to ensure we make a good use of our development resources (i.e. developers&#8217; time and brains) focusing on things that bring more value to our users. In the past we had the feeling that many important things were always postponed because the developers were flooded by other not so important stuff. Now that feeling is gone (to a great extent) and we have a more clear and shared view of the direction of our development efforts.</p>
+<p>But there is always a drawback. We have accumulated quite some unsolved low-priority bugs. That was an expected consequence, but still it was starting to feel wrong. On one hand, it makes us feel uncomfortable &#8211; replying &#8220;this will have to wait&#8221; so often is not nice, even if it&#8217;s for the shake a bigger goal. On the other hand, the amount of low-priority stuff was affecting the signal/noise ratio on Bugzilla, making harder to distinguish the important stuff.</p>
+<p>So far, dealing with those low-priority bug was something that each developer did on his own, as permitted by the time dedicated to Scrum. In sprint 26 we decided to make that effort an explicit part of the process and to devote a significant portion of the sprint to it. As a result we closed or reassigned a total of 135 bugs that were just sitting in our list.</p>
+<p>Yes, you did read it right. One hundred and thirty five bugs.</p>
+<h3>Storage reimplementation: our testing ISO can already destroy your data</h3>
+<p>On the previous sprint we already showed a screenshot of the installer using the new storage stack to calculate a partitioning proposal. Now the installer can go one step further. As you can see on this animation, the changes are now committed to the disk, meaning the system is actually partitioned, formatted and installed.</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/demo_commit_to_disk.gif" alt="Installation with the new storage stack"></p>
+<p>The process is interrupted after installing the software, when trying to configure and install the bootloader. That was expected because yast2-bootloader has still not been adapted to use the new stack. First of all, because we wanted to leave some fun for sprint 27. But also because we used this sprint (26) to document <a href="https://github.com/yast/yast-bootloader/blob/master/doc/boot_storage_needed_info.md">all the requirements of yast2-bootloader</a> in relation to the new storage stack. Now we have in place all the ingredients to cook an installable ISO.</p>
+<h3>Automatic update of translation files</h3>
+<p>Recently openSUSE has adopted <a href="https://weblate.org">Weblate</a> to perform and coordinate the translation of the software and the project&#8217;s web pages. The <a href="https://l10n.opensuse.org/">openSUSE&#8217;s Weblate instance</a> enables everybody (from dedicated translators to casual contributors) to take part in the process and makes possible to coordinate the translations of openSUSE with the ones for SUSE Enterprise Linux, boosting collaboration between the translators of both projects.</p>
+<p>As YaST developers, is of course our responsibility to ensure that openSUSE&#8217;s Weblate contains always the latest English strings to be translated. Making our developer&#8217;s life easier sometimes not only brings advantages for us but also for our users. Until now, after each code change we had to keep in mind to trigger the translation process for every added or changed English text. Sometimes we were not quick enough so that some English leftovers remained in our awesome YaST when being used in one of the 20 languages where the translation is normally 100% complete.</p>
+<p>Now we finally set up a <a href="https://ci.opensuse.org/">Jenkins</a> job to automate the process of triggering the translation update after code changes. This saves the developers some work and makes the update of translations even faster.</p>
+<p>Looking at <a href="https://l10n.opensuse.org/languages/">Weblate numbers</a>, you can see we have 20 languages that are about 100% translated, another 20 that are translated more than 75% and 37 languages which are translated less than 75%. So we still need some help to bring all languages to 100% coverage. If you are willing to contribute, why not join our team of translators? Check out <a href="https://en.opensuse.org/openSUSE:Localization_guide">the localization guide</a> to get in contact with the coordinators of your preferred language to learn about how to contribute with translations, reviews or by any other mean.</p>
+<h3>Ensure installation of packages needed for booting</h3>
+<p>We got some reports of systems not being able to work after the installation in scenarios in which the user had customized the list of packages to install. That happened because, although the bootloader component of YaST pre-selects for installation all the needed packages, the user can override that selection and manually disable the installation of those packages.</p>
+<p>To prevent this situation, or at least to increase awareness of it, the installer now alerts in the summary screen (the last step before proceeding to installation) if some of the required packages is missing, as you can see in the screenshot below. We still allow the users to shoot their own feet if they insist, but now we warn them very clearly.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/softw.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/softw-300x226.png" alt="Warning about de-selected Grub2 package" width="300" height="226" class="aligncenter size-medium wp-image-12057" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/softw-300x226.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/softw-768x578.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/softw-1024x770.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/10/softw.png 1025w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Progress in the low-vision accessibility of the installer</h3>
+<p>During this sprint, we have been working to make the (open)SUSE installer accessible to people with low-vision impairment. We already <a href="https://lizards.opensuse.org/?p=12019">blogged about it</a> looking for feedback.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/highc.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/highc-300x225.png" alt="One of the new color modes available in the installer" width="300" height="225" class="aligncenter size-medium wp-image-12065" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/highc-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/highc-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/highc.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>In a few days, some changes will land in Tumbleweed:</p>
+<ul>
+<li>Alternative style selection (color and font-sizes). Currently, we offer four options: default (no changes), high contrast (cyan/green/white/black), white on black and cyan on black. Those styles are just a proof of concept in order to test the code changes and, most important, to get feedback from you.</li>
+<li>A <a href="https://bugzilla.suse.com/show_bug.cgi?id=768112">long-standing issue</a>, which prevented to switch to high-contrast mode during installation (shift+F4), has been fixed.</li>
+</ul>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc-300x225.png" alt="Style selection at the beginning of installation" width="300" height="225" class="aligncenter size-medium wp-image-12066" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/linuxrc.png 800w" sizes="(max-width: 300px) 100vw, 300px" /></a><br />
+Although we have made some progress, it is still an ongoing effort and we hope to release more improvements during the upcoming weeks.</p>
+<h3>Recover from broken bootloader configuration</h3>
+<p>There are situations in which YaST Bootloader is not able to read the system configuration. For example, when the udev device originally used by Grub2 is no longer available. In the past that leaded to YaST crashes, requiring a manual fix of the bootloader configuration files. Now YaST correctly detects the situation and offers the option to propose a new configuration with correct devices.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/bootl.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/bootl-300x170.png" alt="YaST bootloader fixing a broken configuration" width="300" height="170" class="aligncenter size-medium wp-image-12058" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/bootl-300x170.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bootl-768x435.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bootl-1024x580.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bootl.png 1346w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Disable autorefresh by default in local media</h3>
+<p>We have changed the default autorefresh flag for the new repositories added by YaST. In the past the autorefresh was enabled for all repositories except CD/DVD media and ISO files.</p>
+<p>With the new defaults the autorefresh is enabled only for remote repositories (like http, ftp, nfs,&#8230;). The reason is that some local repositories might not be always available (e.g. external hard disk, USB flash drive,&#8230;) and the automatic refresh might cause ugly errors when starting the package manager.</p>
+<p>Of course, you can still manually change the autorefresh flag after adding a repository if you need a different value.</p>
+<p><i>Note: The default has been changed in Tumbleweed distribution only, Leap 42.2 or SLE-12-SP2 keep the old defaults. The zypper behavior is unchanged as well, it by default disables autorefresh for all repositories. Only repositories imported from a .repo file have autorefresh enabled. See <code>man zypper</code> for more details.</i></p>
+<h3>Tons of improvements in network bridge handling</h3>
+<p>YaST Network is Swiss Army knife for network configuration which comprehends the management of routing, bonding, bridging and many other things. But, to be honest, the management of bridges was not in the best possible shape. It had quite some usability problems and it was not 100% consistent with the way in which bridges are managed nowadays by <a href="https://en.opensuse.org/Portal:Wicked">Wicked</a> in (open)SUSE. Until now!</p>
+<p>This <a href="https://github.com/yast/yast-network/pull/448">pull request</a> with several screenshots and animations tries to summarize all the changes that have been done during this sprint. Like adapting old configuration files to the new conventions or unifying the UI to make it consistent with the one for managing bonding.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/bridge.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/bridge-300x225.png" alt="Revamped YaST interface for handling bridges" width="300" height="225" class="aligncenter size-medium wp-image-12077" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/bridge-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bridge-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/bridge.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>This revamp includes also quite some usability improvements:</p>
+<ul>
+<li>&#8220;NONE&#8221; is shown instead of 0.0.0.0 for old bridge configuration.</li>
+<li>The bridge master is shown in the enslaved interface.</li>
+<li>The interfaces overview is updated after a bridge is modified.</li>
+</ul>
+<h3>Optimizing read of hosts file</h3>
+<p>It was reported that yast2-network was slow in system with a lot of entries in the <code>/etc/hosts</code> file. We took that as an opportunity to test the new profiler support in YaST. The profiler revealed the problem was in some slow calls to <a href="http://yastgithubio.readthedocs.io/en/latest/architecture/#system-configuration-repository-scr">SCR</a>, the layer traditionally used by YaST to interact with the underlying system&#8230; which sounded like another opportunity. This time an opportunity to expand the use of <a href="https://github.com/config-files-api/config_files_api">CFA</a> (the component we are developing to steady replace SCR) and its <a href="http://augeas.net/">Augeas</a> parser. Since Augeas already supports parsing of <code>/etc/hosts</code> files, it was quite straightforward to implement that into YaST&#8230; and the result is quite impressive.</p>
+<p>The time needed to execute the next command in a system containing a huge <code>/etc/hosts</code> with around 10,000 entries (quite an extreme case, we know) was reduced from 75 seconds to just 20.</p>
+<pre>
+yast2 lan list
+</pre>
+<p>As you can see in <a href="https://github.com/config-files-api/config_files_api/pull/10">this pull request</a>, we also improved CFA itself, greatly reducing the time needed for reading configuration files with Augeas.</p>
+<h3>That&#8217;s all&#8230; until next report</h3>
+<p>Once again, we must conclude the report telling that this was just a small summary of all the work done during the sprint and that we will be back in three weeks with the next report. Or maybe before, now that we are starting to get used to blog more often.</p>
+<p>In any case, see you soon and don&#8217;t forget to have a lot of fun!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/20/highlights-of-yast-development-sprint-26/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Proprietary AMD/ATI Catalyst fglrx 15.12 rpms released for LEAP 42.2</title>
+		<link>https://lizards.opensuse.org/2016/10/15/proprietary-amdati-catalyst-fglrx-15-12-rpms-released-for-leap-42-2/</link>
+		<comments>https://lizards.opensuse.org/2016/10/15/proprietary-amdati-catalyst-fglrx-15-12-rpms-released-for-leap-42-2/#comments</comments>
+		<pubDate>Sat, 15 Oct 2016 16:16:18 +0000</pubDate>
+		<dc:creator><![CDATA[Bruno Friedmann]]></dc:creator>
+				<category><![CDATA[GNOME]]></category>
+		<category><![CDATA[KDE]]></category>
+		<category><![CDATA[Kernel]]></category>
+		<category><![CDATA[42.2]]></category>
+		<category><![CDATA[amd]]></category>
+		<category><![CDATA[fglrx]]></category>
+		<category><![CDATA[xorg]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12052</guid>
+		<description><![CDATA[Warnings There’s no warranties the drivers will work, for you! If you are satisfied with the open-source radeon drivers, don’t risk to break your computer ! Still there will NEVER be a fglrx driver for recent kernel and xorg. So if one of those component change in Leap fglrx will be broken. Actual situation Since [&#8230;]]]></description>
+				<content:encoded><![CDATA[<h3>Warnings</h3>
+<p>There’s no warranties the drivers will work, for you!</p>
+<p>If you are satisfied with the open-source radeon drivers,<span style="color: #ff0000"> <b>don’t risk to break your computer !<br />
+</b></span></p>
+<p>Still there will NEVER be a fglrx driver for recent kernel and xorg. So if one of those component change in Leap fglrx will be broken.</p>
+<h3>Actual situation</h3>
+<p>Since last december, AMD doesn&#8217;t published any update about fglrx so the version is still the 15.12.302 published. A few days ago our beloved Leap release manager Ludwig ask me by email, if there will be an available drivers for Leap 42.2.</p>
+<p>Today, after hacking a bit the last Sebastian Siebert&#8217;s script I&#8217;ve been able to build the drivers for Leap 42.2 RC1, and the driver install fine, and xorg start on my HD5750 (but that&#8217;s all what I can tell).</p>
+<p>I will rebuild the driver once Leap 42.2 will hit its final stage.</p>
+<h3>Repository</h3>
+<pre>zypper ar -cfg -n FGLRX http://geeko.ioda.net/mirror/amd-fglrx/openSUSE_Leap_42.2/ FLGRX
+
+zypper -v refresh -f FGLRX
+
+zypper -v install fglrx64_amdcccle_SUSE422 fglrx64_core_SUSE422 fglrx64_graphics_SUSE422  fglrx64_opencl_SUSE422 fglrx64_xpic_SUSE422</pre>
+<h3>Future</h3>
+<p>AMD has stopped any development for FGLRX, so it is already considered obsolete. But on the other side they make a lot of effort to bring radeon and amdgpu (the free and open source driver) to a decent performance level.</p>
+<p>I don&#8217;t have that much usage anymore of my AMD gpu powered computer, and my HD5750 is now 8 years old already, so I can&#8217;t promise to be able to follow up with changes.</p>
+<h3>Cleanup</h3>
+<p>I removed all the obsoletes packages letting only the last one for each openSUSE version still available. Also the server has no more copy of openSUSE github artwork. If this missing to someone, don&#8217;t hesitate to ask.</p>
+<p>Have fun</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/15/proprietary-amdati-catalyst-fglrx-15-12-rpms-released-for-leap-42-2/feed/</wfw:commentRss>
+		<slash:comments>2</slash:comments>
+		</item>
+		<item>
+		<title>Reducing YaST rebuild time by 30%</title>
+		<link>https://lizards.opensuse.org/2016/10/11/reducing-yast-rebuild-time-by-30/</link>
+		<comments>https://lizards.opensuse.org/2016/10/11/reducing-yast-rebuild-time-by-30/#comments</comments>
+		<pubDate>Tue, 11 Oct 2016 13:51:10 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Build Service]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12030</guid>
+		<description><![CDATA[Here comes the YaST team again trying to flood your aggregator with blog post! Now it&#8217;s time for the story of how we reduced the critical path of the rebuild time of YaST RPM packages from 42min 2s to 29min 40s. Chapter 1: where to optimize Of course, the first step to start fixing something [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Here comes the YaST team again trying to flood your aggregator with blog post! Now it&#8217;s time for the story of how we reduced the critical path of the rebuild time of YaST RPM packages from 42min 2s to 29min 40s.</p>
+<h2>Chapter 1: where to optimize</h2>
+<p>Of course, the first step to start fixing something is finding out what exactly needs to be fixed. In our case, this breaks down into</p>
+<ol>
+<li>knowing the dependencies, and</li>
+<li>knowing the individual build times.</li>
+</ol>
+<h3>Dependencies</h3>
+<p>It is tempting to figure out the dependencies by yourself, by parsing the spec files. But it is hard to do right, and, more importantly, a reinvention of the wheel. The Build Service must know all this to be able to schedule the builds, and provides a convenient way to access it, with <code>osc dependson</code>:</p>
+<pre>
+$ osc dependson YaST:Head openSUSE_Factory x86_64
+[...]
+yast2-x11 :
+   yast2-devtools
+yast2-xml :
+   yast2-core
+   yast2-devtools
+yast2-ycp-ui-bindings :
+   libyui
+   yast2-core
+   yast2-devtools
+</pre>
+<h3>Individual build times</h3>
+<p>For each source package, the Build Service produces not only binary RPMs but also a <code>_statistics</code> file, available in the <a href="https://build.opensuse.org/package/statistics/YaST:Head/yast2-core?arch=x86_64&amp;repository=openSUSE_Factory">web UI</a> or via <code>osc getbinaries</code>. We were interested in the total build time, although the data was of limited use because packages can be built on machines with vastly different power and this information is not included.</p>
+<h2>Chapter 2: how to optimize</h2>
+<p>Once we knew which screws needed to be tightened, it was time to do it. Fortunately we had more than one tool for the job.</p>
+<h3>Stop using Autotools</h3>
+<p>Autotools (automake, autoconf and configure) took up a majority of the time needed for building YaST packages. Now that most of those packages are written in pure Ruby, we don&#8217;t need autotools there checking for portability problems that we don&#8217;t have. Autotools are a leftover from the times 15 years back when they were the only sensible option. We <a href="https://twitter.com/timmartin2/status/23365017839599616">have wiped them out</a> where possible and have been <a href="https://github.com/yast/yast-bootloader/commit/5fb46ea8046ea9863e5411ffe1394797e71dde1e">switching</a> to our own <a href="https://github.com/openSUSE/packaging_rake_tasks">set of Rake tasks</a>.</p>
+<h3>Stub the APIs used in tests</h3>
+<p>We run a mixture of unit and integration tests at RPM build time. The downside of this is that we pull in many of the run time dependencies. Fortunately Ruby is a dynamic language and makes it easy to replace interfaces by stubs. That enables us to cut those dependencies.</p>
+<p>
+In fact, we also have some Perl code, notably in yast2-users. Although the stubbing techniques across languages are messier than with pure ruby, they are still effective for our purposes.</p>
+<h3>Do not build specialized documentation</h3>
+<p>This one is simple: if the development documentation is only useful for people that will check out the git repo anyway, then leave it out from the RPM.</p>
+<h2>Appendix: the details</h2>
+<p>
+Enough of high-level explanations, we we promised you graphs, code and all kind of gory details, and a promise made is a debt unpaid. So there we go.</p>
+<h3>Dependency graphs</h3>
+<p>A picture is worth a thousand words. That&#8217;s why we came up with <a href="https://github.com/mvidner/rpm-build-dependencies">this small tool</a> to generate a graphical representation of the dependencies of the YaST packages. In the resulting graphs displayed below, a node is a source package in the build service, and an arrow means &#8220;needs for its build&#8221;. Redundant arrows are omitted (that is, we&#8217;ve erased an A→C if both A→B and B→C existed).</p>
+<p>
+We can see that the most prominent conclusion is that there is a large number of packages that depend on yast2, a collection of basic libraries.</p>
+<p>
+But on top of that, in the original graph there are 6 more layers, and the graph is not very dense there. After our fixes, there are only 4 layers that are more dense.</p>
+<p>Is worth mentioning that the &#8220;layer&#8221; concept only works if the packages take roughly the same time to build; it would not be helpful if there were huge variations. To get a more accurate picture, we should have generated a histogram of build times. But the graph was good enough in our scenario&#8230; and we had to stop the analysis at some point. <img src="https://s.w.org/images/core/emoji/2/72x72/1f642.png" alt="&#x1f642;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>
+The build dependency graph before our fixes:</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before-248x300.png" alt="YaST dependencies graph (before)" width="248" height="300" class="aligncenter size-medium wp-image-12033" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before-248x300.png 248w, https://lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before-768x928.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before-848x1024.png 848w, https://lizards.opensuse.org/wp-content/uploads/2016/10/yast_deps_before.png 1600w" sizes="(max-width: 248px) 100vw, 248px" /></a></p>
+<p>The build dependency graph after our fixes:</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-184x300.png" alt="YaST dependencies graph (after)" width="184" height="300" class="aligncenter size-medium wp-image-11989" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-184x300.png 184w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-768x1255.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-627x1024.png 627w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after.png 1600w" sizes="(max-width: 184px) 100vw, 184px" /></a></p>
+<h3>Build statistics</h3>
+<p>If those graph are not geeky enough for you, here you are the detailed build statistics from the build service</p>
+<pre>
+&lt;buildstatistics&gt;
+  &lt;disk&gt;
+    &lt;usage&gt;
+      &lt;size unit="M"&gt;1118&lt;/size&gt;
+      &lt;io_requests&gt;15578&lt;/io_requests&gt;
+      &lt;io_sectors&gt;2156642&lt;/io_sectors&gt;
+    &lt;/usage&gt;
+  &lt;/disk&gt;
+  &lt;memory&gt;
+    &lt;usage&gt;      &lt;size unit="M"&gt;580&lt;/size&gt; &lt;/usage&gt;
+  &lt;/memory&gt;
+  &lt;times&gt;
+    &lt;total&gt;      &lt;time unit="s"&gt;756&lt;/time&gt; &lt;/total&gt;         &lt;!-- THIS --&gt;
+    &lt;preinstall&gt; &lt;time unit="s"&gt;8&lt;/time&gt;   &lt;/preinstall&gt;
+    &lt;install&gt;    &lt;time unit="s"&gt;72&lt;/time&gt;  &lt;/install&gt;
+    &lt;main&gt;       &lt;time unit="s"&gt;555&lt;/time&gt; &lt;/main&gt;
+    &lt;download&gt;   &lt;time unit="s"&gt;4&lt;/time&gt;   &lt;/download&gt;
+  &lt;/times&gt;
+  &lt;download&gt;
+    &lt;size unit="k"&gt;33564&lt;/size&gt;
+    &lt;binaries&gt;53&lt;/binaries&gt;
+    &lt;cachehits&gt;24&lt;/cachehits&gt;
+    &lt;preinstallimage&gt;preinstallimage.preinstallimage.tar.gz&lt;/preinstallimage&gt;
+  &lt;/download&gt;
+&lt;/buildstatistics&gt;
+</pre>
+<h2>Epilogue</h2>
+<p>This was definitely an interesting journey. We learned quite some  things. Specially we learned that there is still room for improvement, but most likely the time reduction will not pay off for the time invested implementing those improvements.</p>
+<p>We have to be realistic and keep working in other interesting stuff to fuel the next sprint report, coming next week!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/11/reducing-yast-rebuild-time-by-30/feed/</wfw:commentRss>
+		<slash:comments>3</slash:comments>
+		</item>
+		<item>
+		<title>Improving low-vision accessibility of the installer</title>
+		<link>https://lizards.opensuse.org/2016/10/07/improving-low-vision-accessibility-of-the-installer/</link>
+		<comments>https://lizards.opensuse.org/2016/10/07/improving-low-vision-accessibility-of-the-installer/#comments</comments>
+		<pubDate>Fri, 07 Oct 2016 08:25:36 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Accessibility]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[Usability]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12019</guid>
+		<description><![CDATA[In our latest report, we promised you would not have to wait another three weeks to hear (or read) from us. And here we are again, but not with any of the anticipated topics (build time reduction and Euruko 2016), but with a call for help in a topic that could really make a difference [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>In our <a href="https://lizards.opensuse.org/?p=11983">latest report</a>, we promised you would not have to wait another three weeks to hear (or read) from us. And here we are again, but not with any of the anticipated topics (build time reduction and Euruko 2016), but with a call for help in a topic that could really make a difference for (open)SUSE.
+</p>
+<p>
+Nowadays, YaST team is trying to fix a long-standing issue in the installer: <a href="https://bugzilla.suse.com/show_bug.cgi?id=780621">low-vision accessibility</a>. In the past, a user could get a high-contrast mode just pressing shift+F4 during installation. Unfortunately, that feature does not work anymore and, to be honest, changing to a high-contrast palette is not enough. Other adjustments, like setting better font sizes, should be taken into account.
+</p>
+<p>
+Another option is to use the textmode installation and set some obscure variable (<code>Y2NCURSES_COLOR_THEME</code>) to get the high-contrast mode. But it sounds like the opposite to <em>user friendly</em>.
+</p>
+<p>
+  Some days ago, the team fired up the <a href="https://lists.opensuse.org/opensuse-factory/2016-09/msg00593.html">discussion</a> in the opensuse-factory mailing list but we would like to reach as many people as we can to gather information and feedback about this topic. Getting some affected people involved in the process would be really awesome!
+</p>
+<p>For the time being we’re already working on some improvements:</p>
+<ul>
+<li>
+    Adding a Linuxrc option so the user can set the high-contrast mode from the very beginning.
+  </li>
+<li>
+    Fixing <a href="http://bugzilla.novell.com/show_bug.cgi?id=768112">shift+F4 support</a>.
+  </li>
+<li>
+    Improving the high-contrast mode appearance. Below you can see a screenshot of the work in progress.
+  </li>
+</ul>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/10/lowvision.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/10/lowvision-300x225.png" alt="First prototype of the new high contrast mode" width="300" height="225" class="aligncenter size-medium wp-image-12025" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/10/lowvision-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/10/lowvision-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/10/lowvision.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>
+  But we would like to hear from you. You can raise your voice in the already mentioned <a href="https://lists.opensuse.org/opensuse-factory/2016-09/msg00593.html">thread at the opensuse-factory mailing list</a> or leave a comment in the related <a href="https://github.com/libyui/libyui-qt/pull/60">pull request</a> at Github. If you prefer to have a chat, we&#8217;re also available on <a href="irc://irc.opensuse.org/yast">the #yast IRC channel</a> at Freenode&#8230; and we love to see people there. <img src="https://s.w.org/images/core/emoji/2/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" />
+</p>
+<p>
+Please, join us to make YaST even better!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/07/improving-low-vision-accessibility-of-the-installer/feed/</wfw:commentRss>
+		<slash:comments>2</slash:comments>
+		</item>
+		<item>
+		<title>Atualizando o Edison Intel no openSUSE</title>
+		<link>https://lizards.opensuse.org/2016/10/03/atualizando-o-edison-intel-no-opensuse/</link>
+		<comments>https://lizards.opensuse.org/2016/10/03/atualizando-o-edison-intel-no-opensuse/#respond</comments>
+		<pubDate>Mon, 03 Oct 2016 22:50:06 +0000</pubDate>
+		<dc:creator><![CDATA[Alessandro de Oliveira Faria]]></dc:creator>
+				<category><![CDATA[Programming]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=12014</guid>
+		<description><![CDATA[Neste post, disponibilizo os passos efetuados para atualizar o firmware do meu Intel Edison na plataforma openSUSE. ATENÇÃO: Antes de iniciar deixo claro , que o leitor deste post é responsável por qualquer problema que venha a acontecer com o seu aparelho, logo: sendo de sua inteira responsabilidade e risco a utilização das instruções a [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p style="text-align: justify">Neste post, disponibilizo os passos efetuados para atualizar o firmware do meu Intel Edison na plataforma openSUSE.</p>
+<p><span style="color: #ff0000"><strong>ATENÇÃO: Antes de iniciar deixo claro , que o leitor deste post é responsável por qualquer problema que venha a acontecer com o seu aparelho, logo: sendo de sua inteira responsabilidade e risco a utilização das instruções a seguir.</strong></span></p>
+<p>Primeiramente instale o pacote</p>
+<pre>
+# zypper addrepo http://download.opensuse.org/repositories/home:cabelo:desktop/openSUSE_Leap_42.1/home:cabelo:desktop.repo
+# zypper refresh</strong>
+# zypper install dfu-util
+</pre>
+<p>Faça o Download da ultima versão do firmware em https://software.intel.com/pt-br/iot/hardware/edison/downloads</p>
+<p>Posicione a chave <strong>SW1</strong> próxima ao conector micro USB de acordo com a figura abaixo e plugue os 2 cabos USB:</p>
+<p><img class="alignnone size-full wp-image-4211" src="https://cabelovivaolinux.files.wordpress.com/2016/03/intel-edison-setup-1.png" alt="intel-edison-setup-1" width="1027" height="367" /></p>
+<p>E logo a seguir descompacte o arquivo recém baixado e execute o comando ./flashall.sh</p>
+<p><img class="alignnone size-full wp-image-4204" src="https://cabelovivaolinux.files.wordpress.com/2016/03/yocto02.png" alt="yocto02" width="1030" height="460" /></p>
+<p>Se executar o comando sudo screen /dev/ttyUSB0 115200, teremos a seguinte saida no console:</p>
+<p><strong>Starting Reboot&#8230;</strong></p>
+<p><strong>******************************</strong><br />
+<strong> PSH KERNEL VERSION: b0182727</strong><br />
+<strong> WR: 20104000</strong><br />
+<strong> ******************************</strong></p>
+<p><strong>SCU IPC: 0x800000d0 0xfffce92c</strong></p>
+<p><strong>PSH miaHOB version: TNG.B0.VVBD.0000000c</strong></p>
+<p><strong>microkernel built 23:15:13 Apr 24 2014</strong></p>
+<p><strong>******* PSH loader *******</strong><br />
+<strong> PCM page cache size = 192 KB</strong><br />
+<strong> Cache Constraint = 0 Pages</strong><br />
+<strong> Arming IPC driver ..</strong><br />
+<strong> Adding page store pool ..</strong><br />
+<strong> PagestoreAddr(IMR Start Address) = 0x04899000</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong></p>
+<p><strong>U-Boot 2014.04 (Aug 20 2014 &#8211; 16:08:32)</strong></p>
+<p><strong>Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning already done&#8230;</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0x3756edb6</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0x3756edb6</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0x6ad212b0</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xe511e42b</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xe511e42b</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> resetting &#8230;</strong></p>
+<p><strong>******************************</strong><br />
+<strong> PSH KERNEL VERSION: b0182b2b</strong><br />
+<strong> WR: 20104000</strong><br />
+<strong> ******************************</strong><br />
+<strong> SCU IPC: 0x800000d0 0xfffce92c</strong><br />
+<strong> PSH miaHOB version: TNG.B0.VVBD.0000000c</strong><br />
+<strong> microkernel built 11:24:08 Feb 5 2015</strong></p>
+<p><strong>******* PSH loader *******</strong><br />
+<strong> PCM page cache size = 192 KB</strong><br />
+<strong> Cache Constraint = 0 Pages</strong><br />
+<strong> Arming IPC driver ..</strong><br />
+<strong> Adding page store pool ..</strong><br />
+<strong> PagestoreAddr(IMR Start Address) = 0x04899000</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong><br />
+<strong> U-Boot 2014.04 (Jun 19 2015 &#8211; 12:05:55)</strong><br />
+<strong> Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Writing to MMC(0)&#8230; done</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning using GPT</strong><br />
+<strong> Writing GPT: success!</strong><br />
+<strong> Saving Environment to MMC&#8230;</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xb98db2f8</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong><br />
+<strong> U-Boot 2014.04 (Jun 19 2015 &#8211; 12:05:55)</strong><br />
+<strong> Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Writing to MMC(0)&#8230; done</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning using GPT</strong><br />
+<strong> Writing GPT: success!</strong><br />
+<strong> Saving Environment to MMC&#8230;</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xb98db2f8</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong></p>
+<p><strong>U-Boot 2014.04 (Jun 19 2015 &#8211; 12:05:55)</strong></p>
+<p><strong>Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Writing to MMC(0)&#8230; done</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning using GPT</strong><br />
+<strong> Writing GPT: success!</strong><br />
+<strong> Saving Environment to MMC&#8230;</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+<strong> DFU complete CRC32: 0xb98db2f8</strong><br />
+<strong> DOWNLOAD &#8230; OK</strong><br />
+<strong> Ctrl+C to exit &#8230;</strong><br />
+<strong> ######################################################################################</strong></p>
+<p><strong>******* PSH loader *******</strong><br />
+<strong> PCM page cache size = 192 KB</strong><br />
+<strong> Cache Constraint = 0 Pages</strong><br />
+<strong> Arming IPC driver ..</strong><br />
+<strong> Adding page store pool ..</strong><br />
+<strong> PagestoreAddr(IMR Start Address) = 0x04899000</strong><br />
+<strong> pageStoreSize(IMR Size) = 0x00080000</strong></p>
+<p><strong>*** Ready to receive application ***</strong><br />
+<strong> U-Boot 2014.04 (Jun 19 2015 &#8211; 12:05:55)</strong><br />
+<strong> Watchdog enabled</strong><br />
+<strong> DRAM: 980.6 MiB</strong><br />
+<strong> MMC: tangier_sdhci: 0</strong><br />
+<strong> In: serial</strong><br />
+<strong> Out: serial</strong><br />
+<strong> Err: serial</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Writing to MMC(0)&#8230; done</strong><br />
+<strong> Hit any key to stop autoboot: 0</strong><br />
+<strong> Target:blank</strong><br />
+<strong> Partitioning using GPT</strong><br />
+<strong> Writing GPT: success!</strong><br />
+<strong> Saving Environment to MMC&#8230;</strong><br />
+<strong> Writing to redundant MMC(0)&#8230; done</strong><br />
+<strong> Flashing already done&#8230;</strong><br />
+<strong> GADGET DRIVER: usb_dnl_dfu</strong><br />
+<strong> #</strong><br />
+DFU complete CRC32: 0xb98db2f8<br />
+DOWNLOAD &#8230; OK<br />
+Ctrl+C to exit &#8230;<br />
+##############################################################################################</p>
+<p>Se tudo funcionou corretamente, teremos a seguinte tela:</p>
+<p><img class="alignnone size-full wp-image-4215" src="https://cabelovivaolinux.files.wordpress.com/2016/03/yocto03.png" alt="yocto03" width="1160" height="741" /></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/10/03/atualizando-o-edison-intel-no-opensuse/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of YaST development sprint 25</title>
+		<link>https://lizards.opensuse.org/2016/09/28/highlights-of-yast-development-sprint-25/</link>
+		<comments>https://lizards.opensuse.org/2016/09/28/highlights-of-yast-development-sprint-25/#respond</comments>
+		<pubDate>Wed, 28 Sep 2016 13:13:50 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Base System]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Documentation]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Hackweek]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11983</guid>
+		<description><![CDATA[Another development sprint is over. Time flies! In our previous post we already reported about the branching of Tumbleweed and the upcoming releases and about the expected consequences: the landing of some cool features in a less conservative Tumbleweed. We are still dedicating quite some effort to polish the upcoming stable releases (SLE12-SP2 and Leap [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Another development sprint is over. Time flies! In our <a href="https://lizards.opensuse.org/2016/09/07/highlights-of-yast-development-sprint-24/">previous post</a> we already reported about the branching of Tumbleweed and the upcoming releases and about the expected consequences: the landing of some cool features in a less conservative Tumbleweed.</p>
+<p>We are still dedicating quite some effort to polish the upcoming stable releases (SLE12-SP2 and Leap 42.2), but in this sprint we finally found some time to play. Which is great because blogging about new features is more fun than doing it about bug fixes. <img src="https://s.w.org/images/core/emoji/2/72x72/1f642.png" alt="&#x1f642;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<h3>Importing Authorized Keys with AutoYaST</h3>
+<p>When logging in via SSH, public key authentication should be preferred over password authentication. Until now, the best way of setting up the required authorized_keys files in AutoYaST was using the files section.</p>
+<p>However, that approach is tedious and error prone, as you need to make sure you set the correct owner, permissions, etc. Moreover you need to keep in sync the user definition (username and home directory) with the file definition.</p>
+<p>AutoYaST now supports the specification of a set of public keys for each user with a pretty straightforward syntax:</p>
+<pre>
+&lt;user&gt;
+  &lt;username&gt;suse&lt;username&gt;
+  &lt;authorized_keys config:type="list"&gt;
+    &lt;listentry&gt;ssh-rsa your-public-key-1&lt;/listentry&gt;
+    &lt;listentry&gt;ssh-rsa your-public-key-2&lt;/listentry&gt;
+  &lt;authorized_keys&gt;
+&lt;user&gt;
+</pre>
+<p>AutoYaST takes care of writing the files and setting the ownership and the proper permissions.</p>
+<p>While documenting this new feature we realized the AutoYaST documentation about users management could be more detailed, which leads us to&#8230;</p>
+<h3>Improving the documentation</h3>
+<p>Usually developers love to create programs loaded with cool features but hate to write documentation. Fortunately there are people out there who enjoy writing documentation and bringing all those features to light. We have already mentioned in previous reports how grateful we are for having the SUSE documentation team polishing and publishing our documentation drafts and how open and straightforward the process is.</p>
+<p>We updated the YaST documentation to include information about the installer self-update feature, which will debut in SUSE Linux Enterprise 12 SP2 and openSUSE Leap 42.2. As part of <a href="https://github.com/SUSE/doc-sle/pull/69">the same pull request</a> and in the AutoYaST side, some additional improvements were made, including cleaning-up some duplicated information about SUSE registration.</p>
+<p>On the other hand and as a consequence of the above mentioned new feature, the AutoYaST documentation regarding users management has been rewritten adding missing information like groups, user defaults and login settings.</p>
+<p>All our pull requests are already merged in the <code>doc-sle</code> repository. At a later point in time, the SUSE documentation team will review and polish all the new content (including ours) and will publish an up-to-date version of the online documentation. If you don&#8217;t want to wait, you can easily generate an HTML or PDF version of the documentation including all the non-reviewed contributions just following the very simple instructions in the <a href="https://github.com/SUSE/doc-sle/blob/develop/README.adoc">README file</a> of the <code>doc-sle</code> repository.</p>
+<p>Did we already mention we love the open source, programmer-friendly processes of the documentation team? <img src="https://s.w.org/images/core/emoji/2/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<h3>Storage reimplementation: something you can touch</h3>
+<p>We promised news about the storage reimplementation and here they are. Our customized Tumbleweed image (labeled as NewStorage) in the <a href="http://download.opensuse.org/repositories/YaST:/storage-ng/images/iso/">storage-ng OBS repository</a> can now perform some simple actions during installation and display the result to the user.</p>
+<p>First of all, when proposing the timezone settings it will, as usual, check for MS Windows installations in the disk to guess if the hardware clock should be set to UTC. The news is that check is performed using the new storage stack, that offers more functionality in every sprint.</p>
+<p>More important is that the installer will show the partitioning proposal calculated also using the new stack. As you can see in the screenshot below, the screen is way more simpler than the one you would find in a regular Tumbleweed. There are no buttons to change the settings or to run the expert partitioner yet. That doesn&#8217;t mean the functionality is not there, it&#8217;s simply that we prefer to focus first on modifying all the installer steps to use the new stack (what will enable us to use openQA) before refining every screen to add all options there.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/sp.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/sp-300x244.png" alt="The new partitioning proposal" width="300" height="244" class="aligncenter size-medium wp-image-11987" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/sp-300x244.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/09/sp-768x624.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/sp-1024x833.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/09/sp.png 1038w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Right now the system works only in disks containing a MS-DOS style partition table and will always propose a partition-based (no LVM) setup. That&#8217;s because we prefer to solve the hardest scenarios first. Using LVM and/or GPT partition tables is less challenging than the already supported scenario.</p>
+<h3>Reduce global warming by saving OBS build power</h3>
+<p>As you may know, we use the awesome <a href="http://openbuildservice.org/">Open Build Service</a> (OBS) to generate both the YaST rpm packages and the openSUSE/SLE ISO images. Every time the source code of any component changes, OBS rebuilds that component and all the packages that depend on it.</p>
+<p>Our beloved openSUSE and SLE release managers told us that there were several YaST packages that often triggered rebuild of other YaST packages, that triggered yet another rebuild, that triggered&#8230; you got the idea. <img src="https://s.w.org/images/core/emoji/2/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>The mentioned problem slows down the creation of new ISO images, interferes with the continuous integration process (specially visible in Tumbleweed) and wastes valuable OBS resources.</p>
+<p>During this sprint <b>we reduced the rebuild time of YaST by 30%</b>. That&#8217;s for sure interesting, but knowing the details about how we did it could be even more interesting for many readers. We feared the explanation could be too complex and technical to fit into this report&#8230; which gives us just another opportunity for blogging. So expect an upcoming post including interesting technical stuff and crazy graphs like this one.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-184x300.png" alt="YaST dependencies graph" width="184" height="300" class="aligncenter size-medium wp-image-11989" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-184x300.png 184w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-768x1255.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-627x1024.png 627w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after.png 1600w" sizes="(max-width: 184px) 100vw, 184px" /></a></p>
+<h3>Some adjustment for the installer in the LiveCDs</h3>
+<p>One of the good things about working in open source is that sometimes the evolution of the projects you have created can surprise you. Quite some time ago, the YaST team dropped support for the live installer. It was simply too demanding to keep it alive while still doing our regular work (bug fixes and new features for YaST and the regular installer).</p>
+<p>Recently the live installer was removed from Tumbleweed, the only system in which it was still available (after having been dropped in the past from stable openSUSE releases). One could have expected that somebody would decide then to step up and take the maintainership of the live installer.</p>
+<p>But what actually happened was that Fabian Vogt decided to try a different approach we haven&#8217;t considered &#8211; adding the standard network installer to the LiveCDs images of Tumbleweed. He managed to make it work well enough and asked us for help to debug some problems. We fixed the initial problems by disabling the self-update functionality in the LiveCDs (it&#8217;s simply not designed to work on that scenario).</p>
+<p>There are still quite some problems to be resolved to make everything work flawlessly, but if Fabian and others don&#8217;t give up, we will keep assisting them in order to bring the installation back to the LiveCDs&#8230; even in unexpected ways.</p>
+<h3>UI Designer</h3>
+<p>The YaST user interface is quite difficult to design and code. The main problem is that there <del>is</del> was no interactive UI designer where you could build a dialog or modify an existing one. Instead, you had to write new code or modify the existing code which creates and opens the dialog. Then, to see your changes you had to start the YaST module, go to the respective dialog and check its content. If it didn&#8217;t look like you intended, you had to close it, modify the code and start it again. And again&#8230; and again. Very annoying especially if the dialog is hidden deep in the module and you need to take several steps to get there.
+</p>
+<p>
+During Hack Week 14, <a href="https://hackweek.suse.com/14/projects/1522">a project to improve the situation a bit</a> was started. We already had a dialog spy which can be opened by Ctrl+Shift+Alt+Y keyboard shortcut, but that was read-only. You could only inspect the dialog tree and see the details of the selected widget but you could not change anything.
+</p>
+<p>During that Hack Week project it was improved so it could edit the properties of the existing widgets, remove them or even add some new widgets. However the code was more or less a proof of concept than ready to be merged into the YaST UI and released to public. So we decided to finish it in this sprint.</p>
+<p>As usual, it was harder than expected&#8230; but we made it and here is a short demo showing how it works and what you can do there:</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/ui-designer.gif" alt="The new UI designer in action" /></p>
+<p>The new tool is still far from being perfect. The most obvious missing feature is that the dialog is changed in place and you cannot save or export you changes. After closing the dialog everything is lost. But it can still help to try things in the UI or make a quick prototype, specially when discussing solutions with interface designers. Hopefully we find some more time in the future to make it even better.</p>
+<h3>Storage reimplementation: encryption support</h3>
+<p>Although the partitioning proposal still does not support encryption or LVM, we implemented full LUKS (encryption) support in the underlying library (libstorage-ng). Together with the LVM support implemented in the previous sprint, that makes the new library already a valid replacement for the old libstorage in many situations and scenarios. Now it&#8217;s mainly a matter of switching from one version to another in every single YaST component, starting with the expert partitioner that we plan to start redesigning in the next sprint.</p>
+<p>As usual, new features in the library are hard to illustrate, unless you accept the action diagrams as screenshots. In that case, here you can see the sequence of actions performed by the library when creating an encrypted home volume.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/create.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/create-293x300.png" alt="Creation of an encrypted home with libstorage-ng" width="293" height="300" class="aligncenter size-medium wp-image-11995" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/create-293x300.png 293w, https://lizards.opensuse.org/wp-content/uploads/2016/09/create.png 508w" sizes="(max-width: 293px) 100vw, 293px" /></a></p>
+<h3>Syncing keyboard layouts and console fonts in Leap and Tumbleweed</h3>
+<p>In parallel to our Scrum sprints, we have been for some time steady working, together with the openSUSE maintainers of X.Org and systemd, in redesigning how keyboard maps and console fonts are managed by YaST. Some changes were introduced in Tumbleweed some time ago but never made it to SLE (or Leap) because they needed more testing.</p>
+<p>Recently Ludwig Nussel, the Leap&#8217;s release manager, decided that he wanted to sync 42.2 with Tumbleweed in that regard, using the new approach instead of the more conservative SLE one. Thus, we also invested quite some time coordinating again with Stefan Dirsch (X.Org) and Franck Bui (systemd) to push the changes just in time for the beta2 version of Leap 42.2&#8230; just in time to introduce <a href="https://bugzilla.suse.com/show_bug.cgi?id=1000565">bug#1000565</a>, that was honored with its inclusion in the list of <a href="https://en.opensuse.org/openSUSE:Most_annoying_bugs_42.2_dev">most annoying bugs</a> in 42.2 Beta2.</p>
+<p>The bright side is that a fix for the bug has already been provided (see bug report) and you can now finally test the new fonts and keyboard maps. Please, do so and provide feedback in order to get a properly localized Leap 42.2 release.</p>
+<h3>See you soon</h3>
+<p>As usual, this post was just a quick overview of the most interesting part of the sprint, because most people (including ourselves) don&#8217;t want to read about the boring part of the work, which is mainly fixing bugs.</p>
+<p>The good news is that this time you will not have to wait another three weeks to read interesting stuff about YaST. As mentioned, we plan to publish a blog post about the reduction of the build time of YaST. And we will probably also publish a post about the visit of a YaST geecko to <a href="http://euruko2016.org/">Euruko 2016</a>.</p>
+<p>So this time more than ever&#8230; stay tuned!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/09/28/highlights-of-yast-development-sprint-25/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of YaST development sprint 24</title>
+		<link>https://lizards.opensuse.org/2016/09/07/highlights-of-yast-development-sprint-24/</link>
+		<comments>https://lizards.opensuse.org/2016/09/07/highlights-of-yast-development-sprint-24/#respond</comments>
+		<pubDate>Wed, 07 Sep 2016 15:53:59 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[GSOC]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11959</guid>
+		<description><![CDATA[We are back to this blog after another three weeks of (mainly) bug-fixing. In the previous post we promised some news about the self-update functionality and about the LVM support in the new storage stack. We have that&#8230; and much more! So this will be a long post, but it also hides some gems. You [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>We are back to this blog after another three weeks of (mainly) bug-fixing. In the <a href="https://lizards.opensuse.org/?p=11935">previous post</a> we promised some news about the self-update functionality and about the LVM support in the new storage stack. We have that&#8230; and much more!</p>
+<p>So this will be a long post, but it also hides some gems. You will have to keep reading in order to find them.</p>
+<h3>Self-update improvements</h3>
+<p>We have already mentioned in several previous reports the new self-update feature in YaST, which allows updating the installer itself before performing installation of the system.</p>
+<p>But it turned out that the initial implementation had an important drawback. The self-update process happened after having performed some of the installation steps. Then, after updating the installer it was restarted and several of those steps lost their configuration or simply did their operations twice.</p>
+<p>After some discussions we decided to move the self-update step earlier, at the very beginning. For downloading the updates we basically need just working network connection and initialized package management. So we moved the self-update step after the initial automatic network setup (DHCP) and added package initialization to the self-update step.</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/c9d6beac-6e93-11e6-853b-62063269b7dd.gif" alt="The self-update in action" /></p>
+<p>As you can see the self-update step is the very first step in the installation workflow, the language selection and the EULA dialog is displayed <i>after</i> the self update is finished and YaST is restarted. That means all the following steps do not need to remember their state as they will not be called twice after the restart.</p>
+<p>The disadvantage is that we had to drop some features. The self-update step happens before the language selection and the optional disk activation. That means by default the self-update progress (and potential error messages) will be displayed in English. But you can still use the &#8220;language&#8221; boot option and set the language manually via <i>linuxrc</i>.</p>
+<p>On the bright side, we fixed like half a dozen of reported bugs just by relocating the self-update process. So we are pretty sure it&#8217;s worth the price.</p>
+<p>For more details see the updated <a href="https://github.com/yast/yast-installation/blob/master/doc/SELF_UPDATE.md">documentation</a>.</p>
+<h3>Gem one: using the <code>info</code> boot parameter</h3>
+<p>The <code>info</code> boot parameter is a pretty old <i>linuxrc</i> option but it is probably not known well. The parameter is an URL which points to a text file which can contain more boot options.</p>
+<p>When we tested the updated self-update described above we needed to build a driver update disk and pass several boot options. To avoid repeating the same options on the boot command line and to share the boot options across the team we created an <code>info.txt</code> file with content like</p>
+<pre>
+insecure=1
+startshell=1
+dud=ftp://example.com/self_update.dud
+</pre>
+<p>Then you simply boot the installation with <code>info=ftp://example.com/info.txt</code> and <i>linuxrc</i> will read the additional parameters from the file. This can save you a lot of typing, especially if you need to repeat the tests many times.</p>
+<h3>Fixed a security bug for 7 (yes, seven) different SLE releases</h3>
+<p>Some weeks ago, during a routine code review, our security experts found a vulnerability in YaST&#8217;s libstorage related to the way we provide the encryption passwords to some external commands. It is debatable how dangerous this threat really is. It was never a problem during system installation, but it would affect admins who create encrypted partitions (mostly encrypted LVM physical volumes) or crypto files in the installed system.</p>
+<p>A potential attacker with access to <code>/tmp</code> could intercept the password in the very precise moment in which the &#8220;cryptsetup&#8221; or &#8220;losetup&#8221; command are invoked by YaST. It&#8217;s really only a matter of milliseconds. But we don&#8217;t want to take any risks, however small they may be.</p>
+<p>So not only did we fix that for the current code streams, we backported it to all the SLE releases out there that are still supported (even though in some cases it&#8217;s just a single customer) &#8211; back to SLES-10 SP3 from late 2009. That meant backporting the fix to no less than 7 SLE releases (for Leap, those fixes are picked automatically).</p>
+<p>As you can imagine, this got more difficult the farther back in history we went: In a central library like libstorage, things are constantly changing because the tools and environment (kernel, udev, you name it) are constantly changing. There was only a single case where the patch applied cleanly; in all other cases, it involved massive manual work (including testing, of course).</p>
+<p>Was this fun? No, it certainly was not. It was a tedious and most frustrating experience. Do we owe it to our users (paying customers as well as community users) to fix security problems, however theoretical they are? Yes, of course. That&#8217;s why we do those things.</p>
+<h3>Storage reimplementation: every LVM piece in its place</h3>
+<p>As time permits, we keep adding new features to the future libstorage replacement. During previous sprints we added support to read and manipulate all kinds of LVM block devices (PVs, VGs and LVs) but an important aspect was missing: deciding the order of the operations is as important as performing them. We instructed the library about the dependencies between operations and implemented several automated test cases to ensure we don&#8217;t try to do not-so-smart things like removing a physical volume from a volume group and shrinking its logical volumes <i>afterwards</i>.</p>
+<p>The good thing about our automated test-cases is that they generate nice graph that are quite useful to illustrate blog posts. <img src="https://s.w.org/images/core/emoji/2/72x72/1f642.png" alt="&#x1f642;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action-300x48.png" alt="One of the several added test-cases" width="300" height="48" class="aligncenter size-medium wp-image-11972" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action-300x48.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action-768x122.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action-1024x163.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action.png 1531w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Gem two: enjoy Google Summer of Code result</h3>
+<p>As you may know, openSUSE is one of the Free Software organizations selected to take part in Google Summer of Code 2016. For YaST that means we had the huge pleasure of having Joaquín Yeray as student. You can know more about him and his experience diving into YaST and Open Source in <a href="https://joaquinyeray.me/">his GSoC blog</a>. </p>
+<p>But the openSUSE community is not only gaining a new member, we also have a new YaST module. The <a href="https://software.opensuse.org/package/yast2-alternatives">yast2-alternatives</a> package has already been accepted into Tumbleweed and will be also part of Leap 42.2. So we have a new gadget in our beloved configuration Swiss Army knife!</p>
+<p>We liked Joaquín and his module so much that we are revamping the YaST development tutorial to be based on his module (instead of yast2-journal). He is already working on that, so hopefully we will have Joaquín around quite some time still. <img src="https://s.w.org/images/core/emoji/2/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<h3>Unify license handling screens</h3>
+<p>We got a report about the license agreement screen in automatic installation (AutoYaST) being different to the one showed during common installation. So we decided to take a look to the problem and unify them. We are in a quite late phase of the development process of both the next SLE and the next Leap, so we decided to not unify the code but simply adapt one dialog to look like the other. Also we are after string freeze due to translations, so we had to use a trick and reuse another already translated text. We also took the opportunity to fix some small usability problems.</p>
+<p>This is one of those cases in which some images are worth a thousand words, so in order to understand what we did, take a look at the description of <a href="https://github.com/yast/yast-packager/pull/185">this pull request</a>, which includes many images (too many for this blog post).</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864-300x230.png" alt="The new AutoYaST license screen" width="300" height="230" class="aligncenter size-medium wp-image-11965" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864-300x230.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864-768x588.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864-1024x784.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864.png 1040w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Smarter check to avoid duplicated repositories</h3>
+<p>The openSUSE software server defines the online repositories which can be added during installation. The openSUSE DVD also specifies its own online repositories that are always added to the system. And these repositories overlap.</p>
+<p>In openSUSE 42.1 it happened that one repository was added twice, even though there was already a check to avoid that. So we investigated why.</p>
+<p>We found that the URLs for the problematic repository were not exactly the same, one of them had a trailing slash. Therefore we made the URL comparison more tolerant and if the URLs differ only by the trailing slash, they are still considered the same.</p>
+<p>After the fix all repositories are added only once, without any duplicates.</p>
+<h3>Gem three: we are looking for new teammates!</h3>
+<p>After 12 sprint reports, most readers would have already realized that the life as a full-time YaST developer is everything but boring&#8230; and that we are always pretty busy. The fun and the work are better when you share them so&#8230; <a href="https://jobs.suse.com/job/nuremberg/linux-c-ruby-hero-global-location/3486/2930771">we are looking for a new hero</a> to join us in our journey.</p>
+<p>Even if you don&#8217;t feel hacking in YaST would be your thing, maybe you are interested in any of the other <a href="https://www.suse.com/company/careers">jobs at SUSE</a>.</p>
+<h3>Improved documentation about YaST environment variables</h3>
+<p>The behaviour of YaST can be affected by several environment variables, but not all of them are well known by everybody. During this sprint we also decided to invest some time documenting them better. The resulting document will be soon properly integrated in our <a href="http://yast.github.io/documentation.html">centralized documentation for developers</a>, but you can sneak it already <a href="https://github.com/yast/yast.github.io/blob/master/doc/environment-variables.md">here</a>.</p>
+<h3>Branching Tumbleweed and the upcoming stable releases</h3>
+<p>Most of the features and bug-fixes we have blogged about in the last months were incorporated to Tumbleweed, the upcoming Leap 42.2 and the future SLE 12-SP2, since we always try to keep those three codebases as close as possible to each other.</p>
+<p>Now Leap 42.2 and SLE 12-SP2 are close enough to their release date, so we plan to be more conservative with the changes. At the end of this sprint we decided to branch the code for Tumbleweed and for the stable siblings. From now on, most exciting stuff will appear only in Tumbleweed, with SLE 12-SP2 and Leap 42.2 becoming more and more boring.</p>
+<h3>And the wheel keeps on turning</h3>
+<p>So that was a very minimal selection of the most interesting stuff from the just finished sprint. What comes next? Another sprint, of course! We have already planned some interesting stuff for it, like integrating the new partitioning proposal into the installer or finishing the <a href="https://hackweek.suse.com/14/projects/1522">ultra-cool UI designer</a> that was started during latest Hack Week.</p>
+<p>As always, you can follow development in a daily basis in the usual channels (<a href="irc://irc.opensuse.org/yast">#yast IRC channel</a> and the <a href="https://lists.opensuse.org/yast-devel/">yast-devel</a> mailing list) or wait another three weeks for the next sprint report. Meanwhile&#8230; have a lot of fun!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/09/07/highlights-of-yast-development-sprint-24/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+	</channel>
+</rss>

--- a/jekyll/feed2.xml
+++ b/jekyll/feed2.xml
@@ -1,0 +1,616 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	>
+
+<channel>
+	<title>openSUSE Lizards</title>
+	<atom:link href="https://lizards.opensuse.org/feed/" rel="self" type="application/rss+xml" />
+	<link>https://lizards.opensuse.org</link>
+	<description>Blogs and Ramblings of the openSUSE Members</description>
+	<lastBuildDate>Tue, 07 Jun 2016 10:15:48 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>hourly</sy:updatePeriod>
+	<sy:updateFrequency>1</sy:updateFrequency>
+	<generator>https://wordpress.org/?v=4.4.2</generator>
+	<item>
+		<title>Highlights of YaST development sprint 20</title>
+		<link>https://lizards.opensuse.org/2016/06/07/highlights-of-yast-development-sprint-20/</link>
+		<comments>https://lizards.opensuse.org/2016/06/07/highlights-of-yast-development-sprint-20/#comments</comments>
+		<pubDate>Tue, 07 Jun 2016 10:15:48 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11853</guid>
+		<description><![CDATA[The latest Scrum sprint of the YaST team was shorter than the average three weeks and also a little bit &#8220;under-powered&#8221; with more people on vacation or sick leave than usual. The bright side of shorter sprints is that you don&#8217;t have to wait three full weeks to get an update on the status. Here [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>The latest Scrum sprint of the YaST team was shorter than the average three weeks and also a little bit &#8220;under-powered&#8221; with more people on vacation or sick leave than usual. The bright side of shorter sprints is that you don&#8217;t have to wait three full weeks to get an update on the status. Here you have it!</p>
+<h3>Debugger in the installer</h3>
+<p>Until now debugging the YaST installation was usually done by checking the logs. If you needed more details you would add more log calls. This is inconvenient and takes too much time but, as every Ruby developer know, there is a better way. </p>
+<p>Being a fully interpreted and highly introspective language, Ruby offers the possibility of simply intercept the execution of the program and open a interpreter in which is not only possible to inspect the status of the execution, but to take full control of it. </p>
+<p>From now on, you can access those unbeatable debugging capabilities during the installation. All you have to do is boot the installer with <code>Y2DEBUGGER=1</code>.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/06/debugger_session.png" rel="attachment wp-att-11869"><img src="//lizards.opensuse.org/wp-content/uploads/2016/06/debugger_session-300x225.png" alt="Debugger during installation" width="300" height="225" class="aligncenter size-medium wp-image-11869" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/06/debugger_session-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/06/debugger_session-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/06/debugger_session.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Moreover the same mechanism is also available when running YaST in a installed system. Just make sure the rubygem-byebug package is installed and start the YaST module like this:</p>
+<p><code>Y2DEBUGGER=1 yast2 &lt;client&gt;</code></p>
+<p>For more details see the <a href="http://yastgithubio.readthedocs.io/en/latest/debugging/">brand new documentation</a>. You can also see several examples and screenshots of the debugger running in text mode, through the network and in other scenarios in the description of <a href="https://github.com/yast/yast-installation/pull/379">the corresponding pull request</a>.</p>
+<h3>Interface improvements for SSH host keys importing</h3>
+<p>Most software enthusiasts and developers, specially free software lovers, will know the mantra &#8220;<i>release early, release often</i>&#8220;. The earlier you allow your users and contributors to put their eyes and hands on your software, the better feedback you will get in return. And that proved to be true one more time with YaST and the awesome openSUSE community.</p>
+<p>In the <a href="https://lizards.opensuse.org/?p=11822">previous post</a> we introduced a new functionality being added to YaST2 &#8211; more explicit and interactive importing of SSH host keys. Some users quickly spotted some usability problems, right in time for the fixes to be planned for this sprint.</p>
+<p>In the description of <a href="https://github.com/yast/yast-installation/pull/382">this pull request</a> you can see several screenshots of the new interface in several situations, with the new main dialog looking like this.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/06/sshimport2.png" rel="attachment wp-att-11871"><img src="//lizards.opensuse.org/wp-content/uploads/2016/06/sshimport2-300x225.png" alt="New dialog for SSH keys importing" width="300" height="225" class="aligncenter size-medium wp-image-11871" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/06/sshimport2-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/06/sshimport2-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/06/sshimport2.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Iterative development rocks when you have involved users. Keep the constructive criticism!</p>
+<h3>AutoYaST support for SSH host keys importing</h3>
+<p>The user interface was not the only aspect of SSH host keys importing that got improved. For every feature we add to the interactive installer, we always take care of making it accessible from AutoYaST as well. Thus, an AutoYaST profile file can now contain a section like this to control the behavior of the new functionality.<br />
+<code><br />
+&lt;ssh_import&gt;<br />
+&nbsp;&nbsp;&lt;import config:type="boolean"&gt;true&lt;/import&gt;<br />
+&nbsp;&nbsp;&lt;copy_config config:type="boolean"&gt;true&lt;/copy_config&gt;<br />
+&nbsp;&nbsp;&lt;device&gt;/dev/sda2&lt;/device&gt;<br />
+&lt;/ssh_import&gt;<br />
+</code></p>
+<h3>Firewalld support in YaST2-Firewall</h3>
+<p>Another success story about collaboration in the YaST world. In the <a href="https://lizards.opensuse.org/2016/05/02/highlights-of-yast-development-sprint-18/">report about sprint 18</a> we mentioned we had received some contributions in order to add Firewalld support to YaST2-Firewall and that we were collaborating with the authors of those patches to get the whole thing merged in Tumbleweed. After a couple of sprints allocating some time to keep that ball rolling, we can happily announce that YaST2-Firewall in Tumbleweed already supports the &#8220;classic&#8221; SUSEFirewall2 backend and the brand new Firewalld one!</p>
+<h3>Support for vncmanager 3</h3>
+<p>SUSE&#8217;s VNC guru Michal Srb has been working lately in improving the ability to share and reconnect to VNC sessions. Until now, YaST always created a new separate VNC session for every client and closed the session when the client disconnected. There was no simple way to share the session with additional clients or to keep it running after disconnecting.</p>
+<p>Now, thanks to Michal, the remote module can be set up in three different VNC modes: disabled, xinetd and vncmanager. Check the definition of each mode in the description <a href="https://github.com/yast/yast-network/pull/401">of the pull request</a>.</p>
+<h3>New registration UI</h3>
+<p><a href="https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/">Six sprints ago</a>, the &#8220;Local User&#8221; screen got <a href="https://github.com/yast/yast-users/pull/84">some love</a> and the UI was greatly improved. During this sprint, and according to <a href="https://bugzilla.suse.com/show_bug.cgi?id=974626">bug #974626</a>, we have improved the registration UI to make it consistent with the &#8220;Local User&#8221; screen.</p>
+<p>The old interface, displayed below, was pretty confusing. Although it was not obvious at first sight, it offered three options:
+</p>
+<ol>
+<li>Register the system using scc.suse.com by introducing an e-mail and a registration code.</li>
+<li>Register the system using a local SMT server (no e-mail or registration code are used).</li>
+<li>Skip the registration step.</li>
+</ol>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/06/reg-old.png" rel="attachment wp-att-11854"><img src="//lizards.opensuse.org/wp-content/uploads/2016/06/reg-old-300x225.png" alt="Old registration UI" width="300" height="225" class="aligncenter size-medium wp-image-11854" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/06/reg-old-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/06/reg-old-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/06/reg-old.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Options 1 and 2 are mutually exclusive but, if you look at the interface, that fact is not clear. Moreover, we wanted this dialog to be consistent with the new &#8220;Local User&#8221; one.</p>
+<p>The new dialog looks like this, with the three mutually exclusive options being directly presented to the user.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/06/reg-new.png" rel="attachment wp-att-11856"><img src="//lizards.opensuse.org/wp-content/uploads/2016/06/reg-new-300x225.png" alt="New Registration UI" width="300" height="225" class="aligncenter size-medium wp-image-11856" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/06/reg-new-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/06/reg-new-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/06/reg-new.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>As always, redesigning a UI in YaST implies making sure it works nicely in the NCurses interface with screens with a resolution of 80 columns and 25 lines of text. Doesn&#8217;t it look nice (provided the reader has a geeky aesthetic sense)?</p>
+<p><img style="max-width:100%" alt="Text-based Registration UI" src="//lizards.opensuse.org/wp-content/uploads/2016/06/reg-curses.png" /></p>
+<h3>Progress in the new storage layer</h3>
+<p>As usual, progress goes steady in the rewrite of the storage layer. In this sprint we invested some time into the partitioning proposal, which is now able to propose a good layout in some very complex scenarios with highly fragmented disks with limited partition schemas.</p>
+<p>In addition, preliminary support for LVM was added although is still far from being complete and full-featured.</p>
+<h3>Will be back&#8230; very soon</h3>
+<p>We always finish our reports saying something like &#8220;this was just a sample of all the work done, stay tuned for another report in three weeks&#8221;. But the weeks ahead will be a little bit unusual. This week a SUSE internal workshop is taking place. That means that many YaST developers are focusing on stuff different from their daily duty. In addition, <a href="https://events.opensuse.org/conference/oSC16">openSUSE Conference&#8217;16</a> and <a href="https://hackweek.suse.com">Hackweek 14</a> are both round the corner. As a result of all those &#8220;distractions&#8221;, next sprint will be shorter than usual (just one week) and will not start immediately. Expect next report at some point close to the start of openSUSE Conference. By the way&#8230; see you there!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/06/07/highlights-of-yast-development-sprint-20/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of YaST development sprint 19</title>
+		<link>https://lizards.opensuse.org/2016/05/18/highlights-of-yast-development-sprint-19/</link>
+		<comments>https://lizards.opensuse.org/2016/05/18/highlights-of-yast-development-sprint-19/#respond</comments>
+		<pubDate>Wed, 18 May 2016 12:14:46 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Software Management]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11822</guid>
+		<description><![CDATA[Here we are after another Scrum sprint with our usual report about the activity in YaST development. Trusted boot YaST bootloader module got a new option, Trusted Boot (FATE#316553). It installs TrustedGRUB2 instead of the regular GRUB2. Trusted Boot means measuring the integrity of the boot process, with the help from the hardware (a TPM, [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Here we are after another Scrum sprint with our usual report about the activity in YaST development.</p>
+<h3>Trusted boot</h3>
+<p>YaST bootloader module got a new option, Trusted Boot (<a href="https://fate.suse.com/316553">FATE#316553</a>). It installs TrustedGRUB2 instead of the regular GRUB2.  Trusted Boot means measuring the integrity of the boot process, with the help from the hardware (a TPM, Trusted Platform Module, chip).</p>
+<p>It enables some interesting things which we unfortunately haven&#8217;t provided out of the box. We give you a bootloader which measures the boot integrity and places the results in Platform Configuration Registers (PCRs).</p>
+<p>First you need to make sure Trusted Boot is enabled in the BIOS setup (the setting is named Security / Security Chip on Thinkpads, for example). Then you can enable the new YaST Bootloader option that will install TrustedGRUB2.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/05/42c4377c-1b88-11e6-8287-236106b6f4d9.png" rel="attachment wp-att-11827"><img src="//lizards.opensuse.org/wp-content/uploads/2016/05/42c4377c-1b88-11e6-8287-236106b6f4d9-300x234.png" alt="Trusted boot in YaST Bootloader" width="300" height="234" class="aligncenter size-medium wp-image-11827" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/05/42c4377c-1b88-11e6-8287-236106b6f4d9-300x234.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/05/42c4377c-1b88-11e6-8287-236106b6f4d9-768x599.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/05/42c4377c-1b88-11e6-8287-236106b6f4d9.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>In the description of <a href="https://github.com/yast/yast-bootloader/pull/329">this pull request</a> you can find a more detailed explanation including some commands and hexadecimal dumps to check the result. Geek pr0n!</p>
+<h3>SSH keys importing&#8230; and a glance at a YaST Developer&#8217;s life</h3>
+<p>When looking at any software project, it&#8217;s common to find some feature or piece of code that is there due to the so-called &#8220;historical reasons&#8221;. YaST2 code-base has been around since 1999, adapting to changes and new requirements in a (almost literally) daily basis since then. That leads to a new level of heritage &#8211; the &#8220;prehistoric reasons&#8221;. Working in the YaST Team implies coding, debugging, testing&#8230; and archaeological research.</p>
+<p>We got a <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=956976">bug report</a> about the installer &#8220;stealing&#8221; some SSH host keys (but not all of them) from previously installed systems. It was actually the effect of a little-known YaST feature that can look surprising (not to say weird) at first sight. Ten years ago, somebody decided that when installing SUSE in a networked environment, where people use SSH to log in, it was better to import SSH keys from a previously installed Linux than to get that &#8220;ssh host key changed&#8221; for everybody who tries to connect. The rational was that forcing everybody to change the ~/.ssh/known_hosts file often could become a security breach, since people could get used to ignore the security warnings. Welcome to the world of historical reasons. <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /> Moreover, it was decided that the operation should be performed without showing any information to the users, in order to not confuse them.</p>
+<p>More or less at the same time (we are still talking about 2006), it was decided to introduce importing of users from an existing system, this time with user interaction. The YaST developers decided that it would be fine to share some mechanisms in the implementation of both features. Another step into the historical reasons void.</p>
+<p>Fast forward to the present. After several fate entries, bug reports and redesigns over the years, we decided to make the importing of SSH host keys more visible and usable, to make both functionalities (SSH import and users import) more independent and more clean and to take the first step to clean up the insanity introduced through the years (see <a href="https://features.opensuse.org/320873">fate#320873</a> for details).</p>
+<p>The installer does not longer silently just import the SSH host keys from the most recent Linux installation on the disk (remember, you might have several distributions installed), it has now become a part of the installation proposal dialog:</p>
+<p><img style="max-width:100%" alt="SSH host keys proposal" src="//lizards.opensuse.org/wp-content/uploads/2016/05/f93f82cc-1c19-11e6-95ae-0e7e82c22eb4.png" /></p>
+<p>And from there you can change it:</p>
+<p><img style="max-width:100%" alt="SSH host keys selection" src="//lizards.opensuse.org/wp-content/uploads/2016/05/08b01bfe-1c1a-11e6-84f8-ee8d5cd8c3ab.png" /></p>
+<p>Notice that one of the options is &#8220;none&#8221;, so copying of previous keys is not longer enforced. In addition, now is also possible to import the rest of the SSH configuration in addition to the keys.</p>
+<h3>Disabling local repositories</h3>
+<p>When installing from a local media, like a CD/DVD or an USB stick, those sources were still enabled after the installation. It potentially could cause problems during software installation, upgrade, migration, etc. because an old or obsolete installation source is still there. On the other hand, if the source is physically removed (for instance, ejecting the CD/DVD), zypper will complain about that source not being available.</p>
+<p>Fortunately, this behavior will change in future SUSE/openSUSE versions. Now, at the end of the installation, YaST will check every local source disabling those whose products are available also through a remote repository (so they&#8217;re not needed at all).</p>
+<h3>Smart bonding with NPAR and SR-IOV interfaces</h3>
+<p>Support for bonding interfaces with NPar or SR-IOV capabilities has also been improved during this sprint. Too many weird words in one sentence? Don&#8217;t worry, we actually love to explain things.</p>
+<p>Bonding is a way to combine multiple network connections to increase the throughput and bandwidth and to provide redundancy. On the other hand, NPAR and SR-IOV are technologies that provide the capability to create multiple virtual devices from the same physical or ethernet port.</p>
+<p>Until this sprint, YaST offered no way to know whether two interfaces with these capabilities were sharing the same physical port. As a result, users could bond them without realizing that they were not getting the desired effect in terms of redundancy.</p>
+<p>Information about the physical port ID has been added to all the relevant dialogs for all devices supporting it, like it&#8217;s shown in the following screenshots.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/05/bonding1-1.png" rel="attachment wp-att-11835"><img src="//lizards.opensuse.org/wp-content/uploads/2016/05/bonding1-1-300x232.png" alt="Physical ports" width="300" height="232" class="aligncenter size-medium wp-image-11835" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/05/bonding1-1-300x232.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/05/bonding1-1.png 519w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/05/bonding2.png" rel="attachment wp-att-11834"><img src="//lizards.opensuse.org/wp-content/uploads/2016/05/bonding2-300x185.png" alt="More physical ports" width="300" height="185" class="aligncenter size-medium wp-image-11834" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/05/bonding2-300x185.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/05/bonding2.png 579w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Additionally, the user will be alerted when trying to bond devices sharing the same physical port.</p>
+<p><img class="aligncenter" style="max-width:100%" alt="Bonding warning" src="//lizards.opensuse.org/wp-content/uploads/2016/05/warning-1.png" /></p>
+<p>Last but not least, following the Boy Scout Rule (also known as <a href="http://martinfowler.com/bliki/OpportunisticRefactoring.html">opportunistic refactoring</a>), we took the opportunity to fix some small quirks in YaST Network, like the counter-intuitive sorting of devices in some lists.</p>
+<h3>Paying our debts: much better cleanup rules in Snapper</h3>
+<p>Somebody said once &#8220;<i>a promise made is a debt unpaid</i>&#8220;. In the <a href="https://lizards.opensuse.org/?p=11800">previous post</a> we promised you all an article on Snapper.io detailing the new space-aware cleanup introduced in Snapper. <a href="http://snapper.io/2016/05/18/space-aware-cleanup.html">Here you are!</a></p>
+<h3>That&#8217;s all folks</h3>
+<p>Enough for a blog post. That&#8217;s of course not all we did during the last sprint (to the contrary, it&#8217;s just around 20% of the finished work according to the story points count) but, you know, we need to go back to hacking!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/05/18/highlights-of-yast-development-sprint-19/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of YaST development sprint 18</title>
+		<link>https://lizards.opensuse.org/2016/05/02/highlights-of-yast-development-sprint-18/</link>
+		<comments>https://lizards.opensuse.org/2016/05/02/highlights-of-yast-development-sprint-18/#comments</comments>
+		<pubDate>Mon, 02 May 2016 13:03:39 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Software Management]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11800</guid>
+		<description><![CDATA[The wait is over, the report of the latest Scrum sprint of the YaST Team is here! In the previous post we promised that after this sprint we would have much more to show&#8230; and now we do. This sprint was quite productive, so let&#8217;s go straight to the most interesting bits. More improvements in [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>The wait is over, the report of the latest Scrum sprint of the YaST Team is here! In the previous post we promised that after this sprint we would have much more to show&#8230; and now we do. This sprint was quite productive, so let&#8217;s go straight to the most interesting bits.</p>
+<h3>More improvements in the self-update</h3>
+<p>The YaST self-update feature mentioned in the two previous blog posts (<a href="https://lizards.opensuse.org/?p=11748">sprint 16</a> and <a href="https://lizards.opensuse.org/?p=11777">sprint 17</a>) has also received a couple of improvements.</p>
+<p>At <a href="https://gist.github.com/teclator/7bab6f4037992e66b1461e0696cf7f0a">this gist</a> (with screenshots) you can see some of the fixes done when going back and forward in the work-flow after an installer self-update.</p>
+<p>But even more important are the improvements done in AutoYaST to properly handle the new feature. If you want to use your own self-update repository you have to specify it on the boot command line. This is easy in a single installation, but if you want to install many machines using AutoYaST then writing the possibly long URL at each installation again sounds annoying.</p>
+<p>In this sprint we improved handling of the custom update URL so that it can be read from the AutoYaST XML profile. Now you need to write the custom URL only once into the profile and it will be used automatically in every AutoYaST installation.</p>
+<p>There is not much to show in the UI, the log proves that the self update was really loaded.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/04/autoyast-self-update.png" rel="attachment wp-att-11805"><img src="//lizards.opensuse.org/wp-content/uploads/2016/04/autoyast-self-update-300x225.png" alt="AutoYaST self-update" width="300" height="225" class="aligncenter size-medium wp-image-11805" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/04/autoyast-self-update-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/04/autoyast-self-update-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/04/autoyast-self-update.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>You can find more details about specifying the URL in the profile and evaluating the self-update repository URL at the <a href="https://github.com/yast/yast-installation/blob/master/doc/SELF_UPDATE.md#where-to-find-the-updates">documentation</a>.</p>
+<h3>Goodbye perl-Bootloader</h3>
+<p>For quite some time, we have had the plan to stop using <a href="https://build.opensuse.org/package/show/openSUSE:Factory/perl-Bootloader">Perl-Bootloader</a> as library for yast2-Bootloader and finally we managed to make it happen. There were many reasons for this change.</p>
+<p>From the user point of view, the most visible reasons were speed and size. Getting rid of Perl-Bootloader means that we not longer perform hardware probing twice (one for Perl-Bootloader and another one for <code>grub2-config</code>), making kernel updates faster. In addition, we are not only simplifying and reducing the size of yast2-bootloader itself. Dropping the Perl libraries and other associated dependencies, makes possible to have a smaller minimal system, something quite relevant in various environments and scenarios.</p>
+<p>From the developer point of view, the main reason was to unify the used programming languages and also reuse existing solution for file reading and parsing. Now yast2-bootloader uses an <a href="http://augeas.net/">Augeas</a> file parser and serializer, which does not only allow us to have less code to maintain, but also offers smarter editing and better handling of the comments in the configuration files.</p>
+<p>As nice side effects, this change also leaded to the removal of a lot of work-arounds, the simplification of the installation work-flow for bootloader and a very visible improvement in the source code quality. In addition, we improved the test coverage of the whole module to make sure we didn&#8217;t break things too much. But all those would be bold statements if we wouldn&#8217;t have some geeky numbers to prove then, so here they are.</p>
+<ul>
+<li>2945 lines of code added, 5963 removed (<a href="https://github.com/yast/yast-bootloader/compare/4d776...master">4d776&#8230;master</a>)
+</li>
+<li>Unit tests coverage raised <a href="https://coveralls.io/github/yast/yast-bootloader">from 69% to 81%</a>
+</li>
+<li>Code climate quality rating raised from <a href="https://codeclimate.com/github/yast/yast-bootloader/trends">1.73 to 3.31</a> (where 0 is the worst and 4 is the best)
+</li>
+</ul>
+<p>Of course, after such a big rewrite is not unlikely that some new bugs will pop up, but we really believe the improvements are worth the price.</p>
+<h3>Storage reimplementation: calculation of partition location</h3>
+<p>For the <a href="https://build.opensuse.org/project/show/YaST:storage-ng">storage-ng</a> project we made a big step towards a modern system. We do not use geometries and cylinders for disks any longer. Instead we only use sectors.</p>
+<p>The advantage for the user is much better control over the size of new partitions. Since so far the size had to be a multiple of the cylinder size, often 7.84 MiB, it was not possible to create very small partitions, e.g. for the <a href="https://en.wikipedia.org/wiki/BIOS_boot_partition">BIOS boot partition</a>. Also the size of partitions was usually not the exact number entered in YaST, e.g. 509.88 MiB instead of 512 MiB.</p>
+<p>Now the size of partitions is as accurate as possible with the hardware, so usually a multiple of 512 B or 4 KiB.</p>
+<p>Like in the past we also takes care of optimal partition alignment to avoid performance loss due to read-modify-write cycles.</p>
+<h3>Snapper: much better cleanup rules</h3>
+<p><a href="http://snapper.io/">Snapper</a> is a great tool, but the current default configuration usually causes it to be a little bit too greedy with disk space. During this sprint a new set of cleanup rules was implemented, allowing a much more reasonable usage of the disk.</p>
+<p>The feature is already developed, submitted to Factory and even integrated into the next version of SUSE Enterprise that is right now being cooked. But, as you all know, the testing work-flow of openSUSE Tumbleweed (staging projects, openQA and so on) can sometimes cause some delay until the new feature appears in the distribution. As soon as the new feature reaches Tumbleweed, a blog post explaining the new functionality will be published at <a href="http://snapper.io/">snapper.io</a>. Stay tuned!</p>
+<h3>Improved password protection for bootloader</h3>
+<p>The password protection widget in YaST2-Bootloader had not been changed since the GRUB1 times, but GRUB2 allows more fine tunning of the password settings. In fact, it contains a whole user management system with multiple users that can have different permissions and different passwords. For YaST we like to keep things simple, so we support only password for &#8220;root&#8221; user. That was confusing for some people, so we decided to improve the user experience by adjusting some labels&#8230; and fixing some typos in the process. <img src="https://s.w.org/images/core/emoji/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>Two pictures are worth a thousand words, so here you can see how the dialog looked before the change</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/04/boot-password-old.png" rel="attachment wp-att-11803"><img src="//lizards.opensuse.org/wp-content/uploads/2016/04/boot-password-old-300x202.png" alt="BEFORE: boot password dialog" width="300" height="202" class="aligncenter size-medium wp-image-11803" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/04/boot-password-old-300x202.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/04/boot-password-old.png 642w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>and below the new appearance, which adds more explanation to the password specification. Of course, the help text (not displayed in the screenshots) was also improved to reflect the changes.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/04/boot-password-new.png" rel="attachment wp-att-11804"><img src="//lizards.opensuse.org/wp-content/uploads/2016/04/boot-password-new-300x203.png" alt="AFTER: boot password dialog" width="300" height="203" class="aligncenter size-medium wp-image-11804" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/04/boot-password-new-300x203.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/04/boot-password-new.png 642w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Handling of default product patterns</h3>
+<p>The YaST installer implements several possibilities how the default patterns for the installed product should be specified. One of them is using <code>Recommends</code> RPM dependencies for the product package. (The other possibilities include <code>control.xml</code> file or the <code>content</code> file on the medium.)</p>
+<p>The installer by default installs the recommended packages so the default patterns are automatically installed in the initial installation.</p>
+<p>However, this approach makes troubles during system upgrade. If you remove some packages or patterns which are installed by default and then you do a system upgrade the installer will (silently) add the removed packages or patterns back as the <code>Recommends</code> dependencies will pull them in again.</p>
+<p>The solution is to provide another mechanism for selecting the default patterns. The new implementation allows using a specific <code>Provides</code> RPM package tag which specifies the default pattern name for the product.</p>
+<p>The new tag is <code>defaultpattern(pattern)</code> where &#8220;pattern&#8221; is the name of the default pattern. YaST looks for these specific tags and collects the pattern names for all installed or updated products. This step is skipped during package based system upgrade so this should avoid adding unnecessary packages in system upgrade.</p>
+<p>Obviously it depends on the products themselves to switch from the RPM dependencies to this new style. So far it is supported only by the <em>SLES12 SP2 High Availability</em> addon.</p>
+<p>See more details at <a href="https://github.com/yast/yast-packager/wiki/Selecting-the-default-product-patterns">https://github.com/yast/yast-packager/wiki/Selecting-the-default-product-patterns</a>.</p>
+<h3>Storage reimplementation: another step closer to the perfect booting layout</h3>
+<p>A <a href="https://lizards.opensuse.org/?p=11748">couple of reports ago</a> we made public our intention to squeeze some booting experts brains in order to create Ruby classes capable of always proposing a sensible partitioning schema. The delicious result is finally <a href="https://github.com/yast/yast-storage-ng/tree/master/src/lib/storage/boot_requirements_strategies">at the repository</a>, accompanied with a rather complete <a href="https://github.com/yast/yast-storage-ng/blob/master/doc/boot-partition.md">document explaining the logic</a> behind the code.</p>
+<p>If reading Ruby code is not your thing but you are geeky enough, you can also review the <a href="http://paste.opensuse.org/78272293">output generated by the RSpec unit tests</a>, which shows how the new partitioning proposal will behave in all scenarios from the booting requirements point of view.</p>
+<h3>Storage reimplementation: other improvements in the new proposal</h3>
+<p>Apart from the already mentioned improvements in setting the boot-related partitions, the brand new partitioning proposal gained the ability of <em>shrinking Windows partitions</em> when needed (in a sensible and gentle way) and <em>reusing partitions that can be shared</em> with other installed systems, like swap of PReP. Even when sharing a swap partition is not possible and the proposal needs to delete an existing swap partitions to create a different one, it will take care of reusing the old label and UUID, so other systems in the same computer can still find a suitable swap for them even after changing the partitioning layout. Because we all can be better citizens&#8230;</p>
+<p>In addition, we took the first steps to develop a smarter way of proposing a solid partitioning schema when the free space is split over several different disks or disk chunks. Is still a work in progress, but you can trust that in the future (open)SUSE will do a nice job when looking for a home for itself in your sparse hard disk space.</p>
+<h3>Prevent wrong usage of LDL DASD disks in S/390 mainframes</h3>
+<p>The management of storage devices in a Linux system running in a S/390 mainframe is a tricky topic full of corner cases. Depending on the type of disk, its format and other factors, some apparently simple operations (like creating partitions) are not possible. If you are interested in the subject and want to learn a lot of weird acronyms, we would recommend <a href="http://rhinstaller.github.io/blivet/blog/2015/06/s390/">this article</a>.</p>
+<p>We realized that the expert partitioner allowed the user to specify some operations that were actually not supported, which resulted in the installation being aborted at a subsequent step. To avoid that situation, we improved the expert partitioner to detect those unsupported S/390 configurations and alert the user, like it&#8217;s shown in the screenshot below.</p>
+<p><img style="max-width:100%" alt="LDL DADS popup" src="//lizards.opensuse.org/wp-content/uploads/2016/04/ldl_popup.png" /></p>
+<h3>AutoYaST: moving network device renaming to first stage of installation</h3>
+<p>We refactored the network module to unify the handling of device naming. Now AutoYaST assigns the naming udev rules in the 1st stage of the installation already. (yast2-network-3.1.147, autoyast2-3.1.121)</p>
+<h3>New toys for the team</h3>
+<p>We got a new server to run integration tests via openQA and <a href="https://github.com/yast/autoyast-integration-test">AutoYaST</a>.</p>
+<p>The AutoYaST tests now used to take 8 hours but now finish in 1.5 hours.</p>
+<h3>Collaboration with other (open)SUSE Teams</h3>
+<p>Even though we call ourselves &#8220;the YaST team&#8221; we are happy to share the project with other teams in the company and people in the community. During this sprint, we had a chance to review code for two significant features.</p>
+<p>The authentication client module, dealing with LDAP, Kerberos, Active Directory, NSS, PAM, and SSSD, got a big upgrade (yast2-auth-client-3.3.7).</p>
+<p>Since a couple of months, Tumbleweed has had a package for <a href="http://www.firewalld.org/">firewalld</a> (see <a href="https://features.opensuse.org/318356">FATE#318356</a> ). Work is underway to make YaST aware of it but it has not been merged yet. If you are interested you will have to find it in the <a href="https://github.com/yast/yast-yast2">git repo</a>.</p>
+<h3>In closing</h3>
+<p>Definitely, this was a very productive sprint and, as usual, this report is just a sample of the total work delivered by the team. To be precise and to please number lovers, the features and fixes covered by this report represent 85 Scrum story points out of a total of 124 delivered ones. Hopefully enough to keep you entertained until the next report in about three weeks. See you then!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/05/02/highlights-of-yast-development-sprint-18/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 17</title>
+		<link>https://lizards.opensuse.org/2016/04/06/highlights-of-development-sprint-17/</link>
+		<comments>https://lizards.opensuse.org/2016/04/06/highlights-of-development-sprint-17/#respond</comments>
+		<pubDate>Wed, 06 Apr 2016 14:21:03 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11777</guid>
+		<description><![CDATA[This is the fifth report since we started blogging about our development sprints and we have to admit that is the less impressive one so far. We probably underestimated the impact of the combination of Easters holidays and vacations of some team members. But although we were less productive than expected, we still have a [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>This is the fifth report since we started blogging about our development sprints and we have to admit that is the less impressive one so far. We probably underestimated the impact of the combination of Easters holidays and vacations of some team members.</p>
+<p>But although we were less productive than expected, we still have a couple of cool things to show to our beloved users and fellow developers.</p>
+<h3>Handling of file conflicts in packages</h3>
+<p>Until now the package installation in YaST ignored possible file conflicts in the installed packages. In contrast <code>zypper</code> already supports that check for some time.</p>
+<p>File conflicts happen when two packages attempt to install files with the same name but different contents. If such conflicting packages are installed the conflicting files will be replaced losing the previous content. The final file content will also depend on the installation order so some issues might look &#8220;random&#8221;. The package which file has been overwritten is actually broken.</p>
+<p>YaST now displays a confirmation dialog which asks whether to continue with installation despite the conflicts or abort. Previously YaST silently continued with the package installation which could cause serious troubles later.</p>
+<p><img style="max-width:100%" alt="File conflicts" src="https://cloud.githubusercontent.com/assets/907998/13957750/e11da630-f04d-11e5-94a5-ee8b7a67b0ce.gif"></p>
+<p>File conflicts should normally not happen, at least when you use the original distribution repositories. The OBS build checks for some file conflicts during package build and if there really is a file conflict that it should be marked on the RPM level (so you should not be allowed to select the conflicting packages for installation at first place).</p>
+<p>It is up to the user to decide whether it is OK to ignore the conflict or not. If the conflict is for example in a documentation file then ignoring the conflict is usually no problem, but if the conflict is in a binary file or in a system library then it is potentially risky. If you are not sure &#8220;Abort&#8221; is the safe choice here.</p>
+<p>In the description of <a href="https://github.com/yast/yast-yast2/pull/452">this pull request</a> you can see several additional animations showcasing the new feature in a variety of interfaces (Qt, NCurses, command line) and scenarios (software manager, inline installation of extra packages).</p>
+<h3>Improvements in the installer self-update</h3>
+<p>During this sprint, the self-update feature has received several improvements and changes. The most important one is that now it uses libzypp to fetch the updates, delegating signatures checking and that kind of stuff. Obviously, it also means that installer updates will be distributed using regular RPM repositories (instead of Driver Update Disks).</p>
+<p><img style="max-width:100%" alt="Self-Update installer - Unknown GPG" src="//lizards.opensuse.org/wp-content/uploads/2016/04/c7f519fc-fbda-11e5-9367-2e08dd186c1d.png" /></p>
+<p>On the other hand, user&#8217;s driver updates (specified through <a href="https://en.opensuse.org/SDB:Linuxrc#p_dud">dud</a> option) will take precedence over installer updates. They will be applied by Linuxrc anyway, but they&#8217;ll remain on top of installer updates.</p>
+<h3>Fun with Ruby and proxies</h3>
+<p>This is not exactly a new feature or fix in YaST, but something we learned and we decided could be worth sharing in order to save headaches to other people.</p>
+<p>We got a report about YaST ignoring the <code>no_proxy</code> setting in <code>/etc/sysconfig/proxy</code>. After some investigation, it turned out the problem was not in YaST but in the underlying tools, that are also implemented in Ruby. Looks like Ruby have an unexpected (by us, at least) behavior dealing with proxy settings. If you are interested in the details, don&#8217;t miss the information we collected in <a href="https://github.com/yast/yast-registration/wiki/Proxy-Configuration-Issues">this page in the YaST2-Registration wiki</a>, which includes some background and a set of recommendations to follow when setting <code>no_proxy</code>.</p>
+<h3>Unification of network setup during installation</h3>
+<p>As a result of the analysis about how the network settings affect different installation modes and steps, we unified the position and shortcuts of the &#8220;Network Setup&#8221; button. That affected three installation steps.</p>
+<p>A button was added to &#8220;Add On Product&#8221; to avoid going back and forth just to setup some special configuration for some of our network interfaces.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/04/addon.png" rel="attachment wp-att-11791"><img src="//lizards.opensuse.org/wp-content/uploads/2016/04/addon-300x225.png" alt="Add On Product" width="300" height="225" class="aligncenter size-medium wp-image-11791" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/04/addon-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/04/addon-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/04/addon.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>In the &#8220;Disk Activation&#8221; step, the button was moved to the top-right corner to be consistent with other steps.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation.png" rel="attachment wp-att-11792"><img src="//lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation-300x225.png" alt="Disk Activation" width="300" height="225" class="aligncenter size-medium wp-image-11792" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>And to round off consistency we also adjusted the keyboard shortcut in the registration screen.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/04/registration.png" rel="attachment wp-att-11793"><img src="//lizards.opensuse.org/wp-content/uploads/2016/04/registration-300x225.png" alt="Registration" width="300" height="225" class="aligncenter size-medium wp-image-11793" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/04/registration-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/04/registration-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/04/registration.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>New storage library keeps evolving</h3>
+<p>This time we don&#8217;t have any big headline about the development of the new storage layer. We keep collaborating with experts in our attempt to ensure solid solutions for all situations. In addition to booting experts, the input from <a href="http://www.gnu.org/software/parted/">Parted</a> guru Petr Uzel was really valuable during this sprint. We took some important decisions about the integration of the new libstorage and libparted and we made progress in implementing a partitioning proposal that ensures a bootable system in all architectures and configurations, backed with highly readable tests and specs.</p>
+<p>If time and bug reports permit, we&#8217;ll have much more to show after the next sprint&#8230; but that would be in three weeks from now. Meanwhile, have a lot of fun!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/04/06/highlights-of-development-sprint-17/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>AMD Catalyst 15.12 for openSUSE – new makerpm-amd-script is available</title>
+		<link>https://lizards.opensuse.org/2016/03/17/amd-catalyst-15-12-for-opensuse-new-makerpm-amd-script-is-available/</link>
+		<comments>https://lizards.opensuse.org/2016/03/17/amd-catalyst-15-12-for-opensuse-new-makerpm-amd-script-is-available/#comments</comments>
+		<pubDate>Thu, 17 Mar 2016 18:41:13 +0000</pubDate>
+		<dc:creator><![CDATA[Sebastian Siebert]]></dc:creator>
+				<category><![CDATA[Base System]]></category>
+		<category><![CDATA[Desktop]]></category>
+		<category><![CDATA[GNOME]]></category>
+		<category><![CDATA[KDE]]></category>
+		<category><![CDATA[Kernel]]></category>
+		<category><![CDATA[Packaging]]></category>
+		<category><![CDATA[X.org]]></category>
+		<category><![CDATA[11.4]]></category>
+		<category><![CDATA[12.1]]></category>
+		<category><![CDATA[12.2]]></category>
+		<category><![CDATA[12.3]]></category>
+		<category><![CDATA[13.1]]></category>
+		<category><![CDATA[13.2]]></category>
+		<category><![CDATA[42.1]]></category>
+		<category><![CDATA[amd]]></category>
+		<category><![CDATA[ATI]]></category>
+		<category><![CDATA[driver]]></category>
+		<category><![CDATA[fglrx]]></category>
+		<category><![CDATA[Linux]]></category>
+		<category><![CDATA[openSUSE]]></category>
+		<category><![CDATA[radeon]]></category>
+		<category><![CDATA[rpm]]></category>
+		<category><![CDATA[Tumbleweed]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11773</guid>
+		<description><![CDATA[AMD has released the new AMD Catalyst 15.12 (Radeon Crimson Edition). My script replaces the existing packaging script with an updated packaging script. It supports up to Kernel 4.5. (Official support up to Kernel 3.19) Important note: The driver does not work on openSUSE Tumbleweed. Unfortunately, the version of X-server is too new for the [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>AMD has released the new AMD Catalyst 15.12 (Radeon Crimson Edition). My script replaces the existing packaging script with an updated packaging script. It supports up to Kernel 4.5. (Official support up to Kernel 3.19)</p>
+<p><strong>Important note:</strong> The driver does not work on openSUSE Tumbleweed. Unfortunately, the version of X-server is too new for the driver.</p>
+<p>SHA1 is obsolete by now. The script used SHA256 for integrity of the downloaded files.</p>
+<p>New Feature from packaging script:</p>
+<ul>
+<li>systemd support</li>
+</ul>
+<p>Resolved Issues:</p>
+<ul>
+<li>[SWDEV-82980] Ubuntu 15.10 fails when building the .deb packages</li>
+</ul>
+<p>Link: <a href="http://support.amd.com/en-us/kb-articles/Pages/AMDRadeonSoftwareCrimsonEdition15-12LINReleaseNotes.aspx">AMD Catalyst 15.12 Release Notes</a></p>
+<p>Downloads:</p>
+<ul>
+<li>Script: <a href="https://www.sebastian-siebert.de/downloads/makerpm-amd-15.12.sh" target="_blank">makerpm-amd-15.12.sh</a></li>
+<li>SHA1: <a href="https://www.sebastian-siebert.de/downloads/makerpm-amd-15.12.sh.sha256" target="_blank">makerpm-amd-15.12.sh.sha256</a></li>
+</ul>
+<p>Installation guide (English):<br />
+<a href="http://en.opensuse.org/SDB:AMD_fglrx#Building_the_rpm_yourself">http://en.opensuse.org/SDB:AMD_fglrx#Building_the_rpm_yourself</a></p>
+<p>Bruno Friedmann will build the new RPM packages in the fglrx repository. Stay tune!</p>
+<p>If you find any issue with the driver. Don’t hesitate to contact me. I am in contact with AMD and can forward your issue to the right place. Feedback are welcome.</p>
+<p>A report of your system is very helpful beside your feedback. You can generate it with the script:<br />
+<code>su -c 'sh makerpm-amd-15.12.sh -ur'</code></p>
+<p>Have a lot of fun!</p>
+<p>Sebastian<br />
+openSUSE member / Official AMD Packaging Script Maintainer for openSUSE<br />
+German Blog: <a href="https://www.sebastian-siebert.de/2016/03/17/opensuse-proprietaeren-grafik-treiber-amd-catalyst-15-12-als-rpm-installieren/">openSUSE – proprietären Grafik-Treiber AMD Catalyst 15.12 als RPM installieren</a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/03/17/amd-catalyst-15-12-for-opensuse-new-makerpm-amd-script-is-available/feed/</wfw:commentRss>
+		<slash:comments>3</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 16</title>
+		<link>https://lizards.opensuse.org/2016/03/15/highlights-of-development-sprint-16/</link>
+		<comments>https://lizards.opensuse.org/2016/03/15/highlights-of-development-sprint-16/#comments</comments>
+		<pubDate>Tue, 15 Mar 2016 16:28:16 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11748</guid>
+		<description><![CDATA[After three weeks of work, another development sprint is over. So time for another report for our fellow geckos. As usual, quite some time was invested in boring bug fixes and small non-obvious improvements, but we also have some interesting stuff to talk about. Improved UI for the encrypted partitioning proposal We wanted to talk [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>After three weeks of work, another development sprint is over. So time for another report for our fellow geckos. As usual, quite some time was invested in boring bug fixes and small non-obvious improvements, but we also have some interesting stuff to talk about.</p>
+<h3>Improved UI for the encrypted partitioning proposal</h3>
+<p>We wanted to talk about this feature not only because it has a visible impact in the user interface, but also because it&#8217;s a great example of collaboration among the different roles present in a Scrum Team. Formerly our Scrum development team was only formed by the developers of the YaST Team at SUSE. For this sprint (and future ones) the Scrum Team has been powered up with the addition of Ken Wimer as UI/UX expert and Jozef Pupava, one of the openQA.opensuse.org and openQA.suse.de operators.</p>
+<p>We got a feature request to make encryption more visible in this dialog.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/28ea0408-e22b-11e5-8290-9ad25dd65776.png" rel="attachment wp-att-11753"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/28ea0408-e22b-11e5-8290-9ad25dd65776-225x300.png" alt="Old partitioning proposal dialog" width="225" height="300" class="aligncenter size-medium wp-image-11753" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/03/28ea0408-e22b-11e5-8290-9ad25dd65776-225x300.png 225w, http://lizards.opensuse.org/wp-content/uploads/2016/03/28ea0408-e22b-11e5-8290-9ad25dd65776.png 326w" sizes="(max-width: 225px) 100vw, 225px" /></a></p>
+<p>Being software developers used to tools like Vim and Git, we have to admit that the YaST team found the dialog perfectly usable and was having hard times thinking on a better alternative. Fortunately, we now have a UI/UX expert able to bring better alternatives like this one we finally implemented.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/93288588-e22b-11e5-8d9e-d6190a2ad13b.png" rel="attachment wp-att-11755"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/93288588-e22b-11e5-8d9e-d6190a2ad13b-219x300.png" alt="New dialog for partitioning proposal" width="219" height="300" class="aligncenter size-medium wp-image-11755" /></a></p>
+<p>This kind of visual changes in the installer used to cause delays in openQA, because adapting the tests while keeping the openQA machinery running is not always trivial. The great news is that it didn&#8217;t happen this time because our particular openQA superhero was already watching over our steps all along the process.</p>
+<p>So welcome into our Scrum process, Ken and Jozef!</p>
+<h3>System roles</h3>
+<p>A new feature was added to the installer making it possible to quickly adjust several settings for the installation with one shot. You can see a detailed description of the feature, including several screenshots and configurations options <a href="https://github.com/yast/yast-installation/wiki/System-Role">in this wiki page</a> at the Github repository of yast2-installation. And yes, for the impatient we also have a glorious screenshot!</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/460729c4-ea98-11e5-95e7-1a8d90729ff1.png" rel="attachment wp-att-11751"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/460729c4-ea98-11e5-95e7-1a8d90729ff1-300x231.png" alt="System Role dialog" width="300" height="231" class="aligncenter size-medium wp-image-11751" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/03/460729c4-ea98-11e5-95e7-1a8d90729ff1-300x231.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/03/460729c4-ea98-11e5-95e7-1a8d90729ff1.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Storage reimplementation: resizing partitions</h3>
+<p>We have already explained in previous reports that we are performing an integral rewrite of the code managing partitioning and other storage tasks. During this sprint, the brand new library gained the ability to resize all kind of partitions (Linux, Windows, swap, etc.). It&#8217;s nothing that is going to hit the users in the short term but at least we have a couple of screenshots to see the premiere working (yes, we know that screenshots of terminals are not the most fancy stuff).</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/shrink-vfat.png" rel="attachment wp-att-11758"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/shrink-vfat-300x195.png" alt="shrink-vfat" width="300" height="195" class="alignleft size-medium wp-image-11758" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/03/shrink-vfat-300x195.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/03/shrink-vfat.png 674w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/grow-ntfs.png" rel="attachment wp-att-11756"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/grow-ntfs-300x195.png" alt="grow-ntfs" width="300" height="195" class="alignright size-medium wp-image-11756" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/03/grow-ntfs-300x195.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/03/grow-ntfs.png 674w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p><br style="clear:both"></p>
+<h3 style="clear:both">Installer self-update</h3>
+<p>Starting on version 3.1.175, YaST is able to update itself during system installation. This feature will help to solve problems in the installer even after the media has been released. That&#8217;s a huge step towards improving YaST reliability.</p>
+<p>The workflow is pretty simple: during system analysis YaST will search automatically for an update. If such update is found, YaST will download, verify (using GPG) and apply it. Finally, the installation will be resumed using the new version. Nice!</p>
+<p>In the future, self update will be enabled by default. However, if for some reason you don&#8217;t want such a nice feature, you&#8217;re free to disable it. What is more: you can also craft your own update and use it instead the official one passing a custom URL to the installer.</p>
+<p>If you&#8217;re curious, you can check the <a href="https://github.com/yast/yast-installation/blob/master/doc/SELF_UPDATE.md">technical details</a>.</p>
+<h3>Storage reimplementation: the search for the perfect bootloader</h3>
+<p>One of the goals of rewriting the storage layer was to make possible to cope with all the over-complicated requirements involved in the proposal of a good bootloader configuration. This time we don&#8217;t want the different scenarios to simply pop-up over time in a bug-report-oriented basis and start aggregating more and more branches to the existing code in order to support every one of those &#8220;new&#8221; scenarios.</p>
+<p>Changes will come, for sure, but we need a solid ground based in experts knowledge to start building a flexible future-proof code to handle partitioning regarding bootloader. Thus, we started a round of contacts with several experts in all the hardware architectures supported by YaST in order to capture all the knowledge from their brains into a set of Ruby classes. It&#8217;s still a work in progress since squeezing people&#8217;s brains is not always easy, but we already have <a href="https://github.com/yast/yast-storage-ng/blob/master/doc/boot-partition.md">some preliminary document</a>.</p>
+<h3>Consolidating continuous integration tools</h3>
+<p>Continuous integration is a key aspect of software development, specially with methodologies like Scrum. Currently we use both <a href="https://travis-ci.org/">Travis</a> and <a href="http://jenkins-ci.org/">Jenkins</a> for it. Travis builds the pushed commits and pull requests at GitHub, while Jenkins takes care of the integration with the Open Build Service.</p>
+<p>We are investing quite some effort trying to use Jenkins for everything. If you want to know more about the reasons or how the progress is going, check <a href="https://github.com/yast/yast.github.io/blob/master/doc/jenkins-integration.md">the detailed documentation</a>.</p>
+<h3>And much more!</h3>
+<p>As usual, this is just a small sample of the total work delivered by the team during the latest sprint (for Scrum and statistic&#8217;s lovers, it represents 34 story points out of a total of 87 delivered ones). Hopefully enough to keep you informed&#8230; and if it&#8217;s not, you know where you can reach us for more information!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/03/15/highlights-of-development-sprint-16/feed/</wfw:commentRss>
+		<slash:comments>2</slash:comments>
+		</item>
+		<item>
+		<title>TOSprint or not to sprint?</title>
+		<link>https://lizards.opensuse.org/2016/02/27/tosprint-or-not-to-sprint/</link>
+		<comments>https://lizards.opensuse.org/2016/02/27/tosprint-or-not-to-sprint/#comments</comments>
+		<pubDate>Sat, 27 Feb 2016 18:19:44 +0000</pubDate>
+		<dc:creator><![CDATA[Bruno Friedmann]]></dc:creator>
+				<category><![CDATA[Uncategorized]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11732</guid>
+		<description><![CDATA[Report of a week of sprint TOSprint in Paris has just ended (wiki page). What a week! First of all I want to warmfully thank the sponsors, especially Olivier Courtin from Oslandia for the organization, and Mozilla France for hosting us. What is TOSprint? Once a year a bunch of hackers from projects under OsGeo [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p><img src="https://wiki.osgeo.org/images/thumb/d/d1/Logo-TOSPrint_Paris.png/900px-Logo-TOSPrint_Paris.png" alt="TOSprint Paris 2016" style="width:200px;margin:18px;float:left" /><br />
+<h2>Report of a week of sprint</h2>
+<p>TOSprint in Paris has just ended (<a href="https://wiki.osgeo.org/wiki/Paris_Code_Sprint_2016">wiki page</a>).</p>
+<p><b>What a week!</b></p>
+<p>First of all I want to warmfully thank the sponsors, especially Olivier Courtin from Oslandia for the organization, and Mozilla France for hosting us.</p>
+<h3>What is TOSprint?</h3>
+<p>Once a year a bunch of hackers from projects under OsGeo umbrella, meet in a face to face sprint.<br />
+This year it happenned in Paris with great number of participants (52).</p>
+<p>There was globally five big groups, and if each community was running its own schedule,<br />
+there was a lot of cross echanges too.</p>
+<p><a href="https://flic.kr/p/ErD5E8"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/TOSprint_Paris_Mozilla.png" alt="TOSprint Mozilla" width="600" height="187" class="aligncenter size-full wp-image-11740" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/TOSprint_Paris_Mozilla-300x94.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/TOSprint_Paris_Mozilla.png 600w" sizes="(max-width: 600px) 100vw, 600px" /><br />
+<caption>Mateusz Łoskot</caption>
+<p></a></p>
+<h3>Personal objectives</h3>
+<p>My main objective, except being enough luckly to be a sponsor, was to go there and be in direct contact with upstream.</p>
+<p>This can help a lot to improve packages, and create new ones.</p>
+<p>Moreover, as one of my openSUSE&#8217;s Application:Geo peer maintainer, Angelos Kalkas was also participating, we decided to make somes changes, and improve the situation of the repository.</p>
+<p><span id="more-11732"></span></p>
+<h3>openSUSE packaging</h3>
+<p>We were using a Staging repository to test the global changes to minimize the breakage on the main repo, kinda à la Factory <img src="https://s.w.org/images/core/emoji/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>Let&#8217;s talk about what you will get once the rebuild will finished:<br />
+<b>* gdal</b> goes to 2.0.2 which is big jump since version 1.11</p>
+<p><b>* postgis</b> got upgrade to 2.2.1 with sfcgal as dependency so 3D operations are avalaible.</p>
+<p>I added two interesting extensions for postgresql/postgis database<br />
+ <b>&#8211; pgRouting :</b> a long time missing extension in our repository. see <a href="http://pgrouting.org/">pgrouting.org</a><br />
+ <b>&#8211; pointcloud :</b> allow you to store and work with pointcloud in postgresql and also contain a postgis extension. see <a href="https://github.com/pgpointcloud/pointcloud">https://github.com/pgpointcloud/pointcloud</a><br />
+Both packages are respecting the postgresql/postgis naming scheme: so to install pointcloud on a postgresql94 server you will install postgresql94-pointcloud package.<br />
+They are available at least for 13.2, Leap 42.1, Tumbleweed.</p>
+<p>A big thanks to Paul Ramsey for his help resolving the issues raised. Especially the advise to stick to -j1 during compilation of postgis <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p><b>* PDAL <a href="http://www.pdal.io/">pdal.io</a></b> (with libght) is a point cloud abstraction layer which is under active development and should<br />
+in the future replace libLAS once the compatible C interface will be written.<br />
+  A big thanks to Howard Butler, for helping to get all packaging issues resolved.</p>
+<p><b>* Mapserver :</b> <a href="http://mapserver.org">mapserver.org</a><br />
+During the week, mapserver team made impressive changes:<br />
+ &#8211; First by closing numerous github issues which didn&#8217;t get updates for a long time.<br />
+They run a bot script which automatically close the github issue, and users get a nice message about it.<br />
+Perhaps it could inspire us, on how we write closing ticket in bugtriage.<br />
+<a href="https://www.flickr.com/photos/139706282@N06/24936988840/in/album-72157664338100169/" title="OSGeo TOSprint Paris"><img src="https://farm2.staticflickr.com/1508/24936988840_183b1b805f_n.jpg" width="320" height="213" alt="OSGeo TOSprint Paris"></a></p>
+<pre style="background:gray;color:white;font-style:italic">
+  This is an automated comment
+
+  This issue has been closed due to lack of activity. This doesn't mean the issue is invalid,
+  it simply got no attention within the last year. Please reopen with missing/relevant information
+  if still valid.
+
+  Typically, issues fall in this state for one of the following reasons:
+
+      Hard, impossible or not enough information to reproduce
+      Missing test case
+      Lack of a champion with interest and/or funding to address the issue
+</pre>
+<p> &#8211; Part of the team took the challenge to update all the tutorial material.<br />
+ &#8211; A number of question about the future of mapscript : lacking maintenance resources (humans and or funding)<br />
+ &#8211; Bugfix release on thursday night. 6.4.3 and 7.0.1</p>
+<p>For openSUSE, I&#8217;ve been discussing a lot with Thomas Bonfort.<br />
+The idea would be to be able to propose at least two or more versions that receive security and bug fixes. Actually the 6.4 and the 7.0 branches.<br />
+This will allow people to smoothly upgrade their map files, when there&#8217;s breakage or adaptation needed.</p>
+<p>I classify this request as a good idea, and started analyzing what we can do. So its actually a work in progress.</p>
+<h3>Conclusion</h3>
+<p>There&#8217;s nothing more enthusiastic (for me) than participating to a FLOSS event. If some days are more frustrating than others, the others serve to build this free world we all need.<br />
+So I would like to ping your attention : <b> all FLOSS software and communities need your contribution </b>. If you&#8217;re using one of them, become interested in how it is built, organized, start to learn today how to contribute, and enjoy your journey.</p>
+<p>There&#8217;s more to come, especially on the mapserver side, and more and more packages.<br />
+Stay tuned!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/27/tosprint-or-not-to-sprint/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 15</title>
+		<link>https://lizards.opensuse.org/2016/02/25/highlights-of-development-sprint-15/</link>
+		<comments>https://lizards.opensuse.org/2016/02/25/highlights-of-development-sprint-15/#comments</comments>
+		<pubDate>Thu, 25 Feb 2016 11:49:55 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11707</guid>
+		<description><![CDATA[We know you have missed the usual summary from the YaST trenches. But don&#8217;t panic, here you got it! As usual, we will only cover some highlights, saving you from the gory details of the not so exciting regular bugfixing. Package notifications libzypp has a nice feature that enables packages to display notifications when they’re [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>We know you have missed the usual summary from the YaST trenches. But don&#8217;t panic, here you got it! As usual, we will only cover some highlights, saving you from the gory details of the not so exciting regular bugfixing.</p>
+<h3>Package notifications</h3>
+<p>libzypp has a nice feature that enables packages to display notifications when they’re installed/upgraded. Zypper takes advantages of this feature and shows that information when a package is installed/upgraded. For example, if you install <code>mariadb</code> package, Zypper will inform you about setting up a database root password and so on.</p>
+<p>If you installed any of those packages with YaST, you missed that piece of information… until now! Starting on <code>yast2 3.1.175</code> YaST will show packages notifications.</p>
+<p><img class="aligncenter" src="https://cloud.githubusercontent.com/assets/15836/13257232/e7e23058-da45-11e5-8e7d-b116f47c686c.png" alt="installation-messages-qt" /></p>
+<p><img class="aligncenter" src="https://cloud.githubusercontent.com/assets/15836/13257235/ea6ecade-da45-11e5-91ff-579cb257b859.png" alt="installation-messages-ncurses" /></p>
+<p>The only exception is when doing a regular installation (or autoinstallation), as we want to show as few dialogs as possible.</p>
+<h3>Registration Codes from a USB Stick</h3>
+<p>During the installation of a SUSE Linux Enterprise product, you are asked for a registration code. Previously you had to remember it and type it by hand. Now the code can be read from USB storage.</p>
+<p><img src="https://cloud.githubusercontent.com/assets/102056/13245125/4e0bf5de-da0b-11e5-839a-9d8d70052149.png" alt="regcode-from-usb" /><br />
+<img src="https://cloud.githubusercontent.com/assets/102056/13255345/127cc83c-da46-11e5-97b5-bc6365361cfd.png" alt="regcode-from-usb-extensions" /></p>
+<p>Insert a USB stick at installation boot time or at the latest before you proceed from the first installation screen (Language, Keyboard and License Agreement). That stick should contain the registration codes either at <code>/regcodes.txt</code> or at <code>/regcodes.xml</code>. In the registration dialogs, the input fields will be prefilled.</p>
+<p>The syntax of the files is as follows. In the file identify the product with the name quoted by <code>zypper search --type product</code> or <code>SUSEConnect --list-extensions</code> (without the /version/architecture part).</p>
+<p>regcodes.txt:
+<pre>
+SLES    cc36aae1
+SLED    309105d4
+
+sle-we  5eedd26a
+sle-live-patching 8c541494
+</pre>
+<p>regcodes.xml: (xml wins if both xml and txt are present)
+<pre>
+&lt;?xml version="1.0"?&gt;
+&lt;profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns"&gt;
+  &lt;suse_register&gt;
+    &lt;!-- See https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Register.Extension --&gt;
+    &lt;addons config:type="list"&gt;
+      &lt;addon&gt;
+        &lt;!-- Name of add-on as listed by "zypper search --type product" --&gt;
+        &lt;name&gt;sle-we&lt;/name&gt;
+        &lt;reg_code&gt;5eedd26a&lt;/reg_code&gt;
+      &lt;/addon&gt;
+      &lt;addon&gt;
+        &lt;name&gt;sle-live-patching&lt;/name&gt;
+        &lt;reg_code&gt;8c541494&lt;/reg_code&gt;
+      &lt;/addon&gt;
+      &lt;addon&gt;
+        &lt;!-- SLES is not an add-on but listing it here allows for combining
+             several base product registration codes in a single file --&gt;
+        &lt;name&gt;SLES&lt;/name&gt;
+        &lt;reg_code&gt;cc36aae1&lt;/reg_code&gt;
+      &lt;/addon&gt;
+      &lt;addon&gt;
+        &lt;name&gt;SLED&lt;/name&gt;
+        &lt;reg_code&gt;309105d4&lt;/reg_code&gt;
+      &lt;/addon&gt;
+    &lt;/addons&gt;
+  &lt;/suse_register&gt;
+&lt;/profile&gt;
+</pre>
+<p></p>
+<h3>Lot of Btrfs-related improvements in the expert partitioner</h3>
+<p>We also invested quite some time improving the support for Btrfs in the expert partitioner. Implementing one requested feature and closing five bugs.</p>
+<p>The following animation shows the feature #320296 (user friendly handling of subvolumes) in action, together with the fix to 965279 (Btrfs settings always overridden with default values).</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/subvolumes-opt.gif" alt="subvolumes-opt" class="aligncenter" /></a></p>
+<p>But we have even more screenshots and animations for the improvements in the expert partitioner. In the description of <a href="https://github.com/yast/yast-storage/pull/190">this pull request</a>, you have screenshots displaying the new dialog that was implemented to fix bug#928641. And in <a href="https://github.com/yast/yast-storage/pull/186">this other pull request</a>, you can see in action the fixes for bug#944252 (snapshots were offered for partitions other than root) and for bug#954691 (fstab options being forgotten for Btrfs partitions).</p>
+<h3>Improving testability of the new storage code</h3>
+<p>In recent posts, we reported how we are about to refactor the storage subsystem of YaST. The improved partition proposal for installation <a href="https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/">presented in the previous summary</a> performs a lot of operations &#8211;  like analyzing what disks are there and what is on each one of them, checking if there already is enough free space and making a best guess on what partitions may be candidates to be removed to make space for a new Linux installation.</p>
+<p>If there are many disks with many partitions, this can get complicated really quickly. So we need a reliable way to test it. Thus, we created a testing framework to build fake storage hardware (disks) with fake partitions and file systems. Although it&#8217;s fake hardware (we can&#8217;t create hard disks out of thin air&#8230; yet), it enables us to do unit tests without setting up virtual machines. With those tests we can cover a lot more scenarios that would otherwise be really difficult to test, with one or many disks, with many partitions of different kinds, with a previously existing RAID array or whatever.</p>
+<p>One nice thing about the new libstorage is that it operates on &#8220;device graphs&#8221; that can be transformed into the GraphViz format for easy visualization. Here you have a nice diagram generated by libstorage based on some fake hardware created from <a href="https://gist.github.com/ancorgs/014c34c3c74b9949f3a2">this YAML specification</a>.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs.png" rel="attachment wp-att-11723"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs-300x136.png" alt="fake-devicegraphs" width="300" height="136" class="aligncenter size-medium wp-image-11723" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs-300x136.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs.png 763w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Better handling of wrong registration code for extensions</h3>
+<p>We also spent some time improving the usability of the section for registration of extensions and modules. Now if the user selects several modules and the registration of some of them fails, the user will be kindly redirected back to the same dialog but only with inputs for the unregistered ones. From there, they can go back to unselect the failing extensions or retry with different (or even with the same) codes.</p>
+<h3>Say goodbye to the &#8220;receive system mail&#8221; checkbox</h3>
+<p>As the last step of the improvements done to the user creation dialog (see the <a href="https://lizards.opensuse.org/?p=11673">previous post</a> for more details). We removed the long-ago meaningless checkbox titled &#8220;Receive System Mail&#8221;. That leaded to the removal of quite some code&#8230; and removing code is usually a good thing. <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<h3>Many other things</h3>
+<p>As usual, this is just a short summary with some highlights. Many other stuff was implemented and several other bugs were fixed but, you know, we cannot blog about everything if we want to invest some time in debugging and coding. <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>See you in the highlights for next sprint, in around three weeks.</p>
+<p>PS.- If you want to be part of the fun, take a look to the YaST-related summer projects we have on the <a href="http://101.opensuse.org/">openSUSE mentoring page</a>.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/25/highlights-of-development-sprint-15/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Sugar on openSUSE</title>
+		<link>https://lizards.opensuse.org/2016/02/17/sugar-on-opensuse/</link>
+		<pubDate>Wed, 17 Feb 2016 14:25:18 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Desktop]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[Packaging]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11705</guid>
+		<description><![CDATA[Built openSUSE Leap based Sugar test images on SUSE Studio, get it from here. If you wish to get involved with the project maintaining packages, fixing/reporting bugs, follow the links on the X11:Sugar build service project page.]]></description>
+				<content:encoded><![CDATA[<p>Built openSUSE Leap based <a href="https://www.sugarlabs.org/">Sugar</a> test images on SUSE Studio, <a href="https://susestudio.com/a/F78UZ4/sugarsuse-leap-42-1">get it from here</a>.</p>
+<p>If you wish to get involved with the project maintaining packages, fixing/reporting bugs, follow the links on the <a href="https://build.opensuse.org/project/show/X11:Sugar">X11:Sugar</a> build service project page.</p>
+]]></content:encoded>
+			</item>
+		<item>
+		<title>Highlights of development sprint 14</title>
+		<link>https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/</link>
+		<comments>https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/#comments</comments>
+		<pubDate>Wed, 03 Feb 2016 08:08:15 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11673</guid>
+		<description><![CDATA[Another three weeks period and another report from the YaST Team (if you don&#8217;t know what we are talking about, see highlights of sprint 13 and the presentation post). This was actually a very productive sprint although, as usual, not all changes have such an obvious impact on final users, at least in the short [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Another three weeks period and another report from the YaST Team (if you don&#8217;t know what we are talking about, see <a href="https://lizards.opensuse.org/2016/01/07/highlights-of-development-sprint-13/">highlights of sprint 13</a> and the <a href="https://lizards.opensuse.org/2015/12/15/lets-blog-about-yast/">presentation post</a>). This was actually a very productive sprint although, as usual, not all changes have such an obvious impact on final users, at least in the short term.</p>
+<h3>Redesign and refactoring of the user creation dialog</h3>
+<p>One of the most visible changes, at least during the installation process, is the revamped dialog for creating local users. There is a full screenshots-packed description of the original problems (at usability and code levels) and the implemented solution in the <a href="https://github.com/yast/yast-users/pull/84">description of this pull request</a> at Github.com.</p>
+<p>Spoilers: the new dialog looks like the screenshot below and the openSUSE community now needs to decide the default behavior we want for Tumbleweed regarding password encryption methods. To take part in that discussion, read the mentioned description and reply to <a href="http://lists.opensuse.org/opensuse-factory/2016-01/msg00496.html">this thread</a> in the openSUSE Factory mailing list.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4.png" rel="attachment wp-att-11675"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4-300x225.png" alt="b12a8f90-c51b-11e5-9ceb-659b6c77bac4" width="300" height="225" class="aligncenter size-medium wp-image-11675" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Beyond the obvious changes for the final user, the implementation of the new dialogs resulted in a much cleaner and more tested code base, including a new <a href="http://www.rubydoc.info/github/yast/yast-yast2/UI/InstallationDialog">reusable class</a> to greatly streamline the development of new installation dialogs in the future.</p>
+<h3>One step further in the new libstorage: installation proposal</h3>
+<p>In the highlights of the previous sprint, we already explained the YaST team is putting a lot of effort in rewriting the layer that access to disks, partitions, volumes and all that. One important milestone in such rewrite is the ability to examine a hard disk with a complex partitioning schema (including MS Windows partitions, a Linux installation and so on) and propose the operations that need to be performed in order to install (open)SUSE. It&#8217;s a more complex topic that it could look at the first glance.</p>
+<p>During this sprint we created a command line tool that can perform that task. Is still not part of the installation process and will take quite some time until it gets there, but it&#8217;s already a nice showcase of the capabilities of the new library.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1.png" rel="attachment wp-att-11682"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1.png" alt="new-storage-proposal-2016-01-27-1900" width="738" height="636" class="aligncenter size-full wp-image-11682" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1-300x259.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1.png 738w" sizes="(max-width: 738px) 100vw, 738px" /></a><br />
+</p>
+<h3>Fixed a crash when EULA download fails</h3>
+<p>If a download error occurred during the installation of any module or extension requiring an EULA, YaST simply exited after displaying a pop-up error, as you can see here.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/0c444926-bb75-11e5-8e6e-029d018c14d3.gif" rel="attachment wp-att-11684"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/0c444926-bb75-11e5-8e6e-029d018c14d3.gif" alt="0c444926-bb75-11e5-8e6e-029d018c14d3" width="700" height="616" class="aligncenter size-full wp-image-11684" /></a></p>
+<p>Now the workflow goes back to the extension selection, to retry or to deselect the problematic extension. Just like this.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/46fb22a6-bb75-11e5-9830-aff1d516e77e.gif" rel="attachment wp-att-11686"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/46fb22a6-bb75-11e5-9830-aff1d516e77e.gif" alt="46fb22a6-bb75-11e5-9830-aff1d516e77e" width="702" height="623" class="aligncenter size-full wp-image-11686" /></a></p>
+<p></p>
+<h3>Continuous integration for Snapper and (the current) libstorage</h3>
+<p><a href="https://github.com/openSUSE/snapper">Snapper</a> and <a href="https://github.com/openSUSE/libstorage/">libstorage</a> now build the Git “master” branch continuously on <a href="http://ci.opensuse.org">ci.opensuse.org</a> (<a href="https://ci.opensuse.org/job/snapper-master/">S</a>, <a href="https://ci.opensuse.org/job/libstorage-master/">L</a>), and commit a passing build to the OBS development project (<a href="https://build.opensuse.org/package/show/YaST:Head/snapper">S</a>, <a href="https://build.opensuse.org/package/show/YaST:Head/libstorage">L</a>), and if the version number has changed, submit the package to Factory (<a href="https://build.opensuse.org/package/show/openSUSE:Factory/snapper">S</a>, <a href="https://build.opensuse.org/package/show/openSUSE:Factory/libstorage">L</a>).</p>
+<p>The same set-up works on <a href="http://ci.suse.de">ci.suse.de</a> (<a href="https://ci.suse.de/job/snapper-master/">S</a>, <a href="https://ci.suse.de/job/libstorage-master/">L</a>), committing to the SUSE&#8217;s internal OBS instance (<a href="https://build.suse.de/package/show/Devel:YaST:Head/snapper">S</a>, <a href="https://build.suse.de/package/show/Devel:YaST:Head/libstorage">L</a>) and submitting to the future SLE12-SP2 (<a href="https://build.suse.de/package/show/SUSE:SLE-12-SP2:GA/snapper">S</a>, <a href="https://build.suse.de/package/show/SUSE:SLE-12-SP2:GA/libstorage">L</a>).</p>
+<p>This brings these two packages up to the level of automation that the YaST team uses for the yast2-* packages, and allows releasing simple fixes even by team members who do not work on these packages regularly.</p>
+<h3>Disk usage stats in installation and software manager: do not list subvolumes</h3>
+<p>While installing software, YaST provides a visual overview of the free space in the different mount points of the system. With Btrfs and its subvolumes feature, the separation between a physical disk and its mount point is not that clear anymore. That resulted in wrong reports in YaST, like the one displayed in the left bottom corner of this screen.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage.png" rel="attachment wp-att-11695"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage.png" alt="broken-disk-usage" width="681" height="468" class="aligncenter size-full wp-image-11695" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage-300x206.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage.png 681w" sizes="(max-width: 681px) 100vw, 681px" /></a></p>
+<p>The actual calculation of free space is performed by libzypp (the Zypper library), YaST only takes care of rendering the result of that calculation in the screen. Thus, we closely collaborated with the Zypper developer, Michael Andres, to teach libzypp how to deal with Btrfs subvolumes. Thanks to his work, with any version of libzypp &gt;= 15.21 (already available in Tumbleweed), you can enjoy an error-free disk usage report.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage.png" rel="attachment wp-att-11696"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage.png" alt="fixed-disk-usage" width="681" height="468" class="aligncenter size-full wp-image-11696" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage-300x206.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage.png 681w" sizes="(max-width: 681px) 100vw, 681px" /></a></p>
+<p>To ensure we have no regressions, the YaST team also contributed a new test to openQA. See it <a href="https://openqa.opensuse.org/tests/117876/modules/yast2_i/steps/7">in action</a>.</p>
+<h3>Cleanup dependencies in YaST systemd services</h3>
+<p>We have received several bug reports about problems executing AutoYaST or YasT2-Firstboot in combination with complex network settings or third party services&#8230; and even in some simple scenarios. Many of these problems boil down to a single culprit &#8211; the dependencies of the YaST related systemd units.</p>
+<p>During this sprint we have simplified the unit files for Tumbleweed and SLE, as you can see in <a href="https://github.com/yast/yast-installation/pull/332/files">this pull request</a>. It&#8217;s a small change but with a huge impact and several implications, so a lot of time was invested into testing during the sprint. The problems seem to be gone, but more AutoYaST and YaST-Firstboot testing would be highly appreciated.</p>
+<h3>Many other things</h3>
+<p>As usual, this is only a brief collection of highlights of all the job done during the sprint. Using Scrum terminology, this represents only 27 story points out of a total of 81 story points delivered by the team during this sprint. Using more mundane words, this is just a third part of what we have achieved during the last three weeks.</p>
+<p>Hopefully, enough to keep you entertained until the next report in other three weeks!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/feed/</wfw:commentRss>
+		<slash:comments>3</slash:comments>
+		</item>
+	</channel>
+</rss>

--- a/jekyll/feed3.xml
+++ b/jekyll/feed3.xml
@@ -1,0 +1,511 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	>
+
+<channel>
+	<title>openSUSE Lizards</title>
+	<atom:link href="https://lizards.opensuse.org/feed/" rel="self" type="application/rss+xml" />
+	<link>https://lizards.opensuse.org</link>
+	<description>Blogs and Ramblings of the openSUSE Members</description>
+	<lastBuildDate>Wed, 06 Apr 2016 14:21:03 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>hourly</sy:updatePeriod>
+	<sy:updateFrequency>1</sy:updateFrequency>
+	<generator>https://wordpress.org/?v=4.4.2</generator>
+	<item>
+		<title>Highlights of development sprint 17</title>
+		<link>https://lizards.opensuse.org/2016/04/06/highlights-of-development-sprint-17/</link>
+		<comments>https://lizards.opensuse.org/2016/04/06/highlights-of-development-sprint-17/#respond</comments>
+		<pubDate>Wed, 06 Apr 2016 14:21:03 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11777</guid>
+		<description><![CDATA[This is the fifth report since we started blogging about our development sprints and we have to admit that is the less impressive one so far. We probably underestimated the impact of the combination of Easters holidays and vacations of some team members. But although we were less productive than expected, we still have a [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>This is the fifth report since we started blogging about our development sprints and we have to admit that is the less impressive one so far. We probably underestimated the impact of the combination of Easters holidays and vacations of some team members.</p>
+<p>But although we were less productive than expected, we still have a couple of cool things to show to our beloved users and fellow developers.</p>
+<h3>Handling of file conflicts in packages</h3>
+<p>Until now the package installation in YaST ignored possible file conflicts in the installed packages. In contrast <code>zypper</code> already supports that check for some time.</p>
+<p>File conflicts happen when two packages attempt to install files with the same name but different contents. If such conflicting packages are installed the conflicting files will be replaced losing the previous content. The final file content will also depend on the installation order so some issues might look &#8220;random&#8221;. The package which file has been overwritten is actually broken.</p>
+<p>YaST now displays a confirmation dialog which asks whether to continue with installation despite the conflicts or abort. Previously YaST silently continued with the package installation which could cause serious troubles later.</p>
+<p><img style="max-width:100%" alt="File conflicts" src="https://cloud.githubusercontent.com/assets/907998/13957750/e11da630-f04d-11e5-94a5-ee8b7a67b0ce.gif"></p>
+<p>File conflicts should normally not happen, at least when you use the original distribution repositories. The OBS build checks for some file conflicts during package build and if there really is a file conflict that it should be marked on the RPM level (so you should not be allowed to select the conflicting packages for installation at first place).</p>
+<p>It is up to the user to decide whether it is OK to ignore the conflict or not. If the conflict is for example in a documentation file then ignoring the conflict is usually no problem, but if the conflict is in a binary file or in a system library then it is potentially risky. If you are not sure &#8220;Abort&#8221; is the safe choice here.</p>
+<p>In the description of <a href="https://github.com/yast/yast-yast2/pull/452">this pull request</a> you can see several additional animations showcasing the new feature in a variety of interfaces (Qt, NCurses, command line) and scenarios (software manager, inline installation of extra packages).</p>
+<h3>Improvements in the installer self-update</h3>
+<p>During this sprint, the self-update feature has received several improvements and changes. The most important one is that now it uses libzypp to fetch the updates, delegating signatures checking and that kind of stuff. Obviously, it also means that installer updates will be distributed using regular RPM repositories (instead of Driver Update Disks).</p>
+<p><img style="max-width:100%" alt="Self-Update installer - Unknown GPG" src="//lizards.opensuse.org/wp-content/uploads/2016/04/c7f519fc-fbda-11e5-9367-2e08dd186c1d.png" /></p>
+<p>On the other hand, user&#8217;s driver updates (specified through <a href="https://en.opensuse.org/SDB:Linuxrc#p_dud">dud</a> option) will take precedence over installer updates. They will be applied by Linuxrc anyway, but they&#8217;ll remain on top of installer updates.</p>
+<h3>Fun with Ruby and proxies</h3>
+<p>This is not exactly a new feature or fix in YaST, but something we learned and we decided could be worth sharing in order to save headaches to other people.</p>
+<p>We got a report about YaST ignoring the <code>no_proxy</code> setting in <code>/etc/sysconfig/proxy</code>. After some investigation, it turned out the problem was not in YaST but in the underlying tools, that are also implemented in Ruby. Looks like Ruby have an unexpected (by us, at least) behavior dealing with proxy settings. If you are interested in the details, don&#8217;t miss the information we collected in <a href="https://github.com/yast/yast-registration/wiki/Proxy-Configuration-Issues">this page in the YaST2-Registration wiki</a>, which includes some background and a set of recommendations to follow when setting <code>no_proxy</code>.</p>
+<h3>Unification of network setup during installation</h3>
+<p>As a result of the analysis about how the network settings affect different installation modes and steps, we unified the position and shortcuts of the &#8220;Network Setup&#8221; button. That affected three installation steps.</p>
+<p>A button was added to &#8220;Add On Product&#8221; to avoid going back and forth just to setup some special configuration for some of our network interfaces.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/04/addon.png" rel="attachment wp-att-11791"><img src="//lizards.opensuse.org/wp-content/uploads/2016/04/addon-300x225.png" alt="Add On Product" width="300" height="225" class="aligncenter size-medium wp-image-11791" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/04/addon-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/04/addon-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/04/addon.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>In the &#8220;Disk Activation&#8221; step, the button was moved to the top-right corner to be consistent with other steps.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation.png" rel="attachment wp-att-11792"><img src="//lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation-300x225.png" alt="Disk Activation" width="300" height="225" class="aligncenter size-medium wp-image-11792" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/04/disk_activation.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>And to round off consistency we also adjusted the keyboard shortcut in the registration screen.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/04/registration.png" rel="attachment wp-att-11793"><img src="//lizards.opensuse.org/wp-content/uploads/2016/04/registration-300x225.png" alt="Registration" width="300" height="225" class="aligncenter size-medium wp-image-11793" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/04/registration-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/04/registration-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/04/registration.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>New storage library keeps evolving</h3>
+<p>This time we don&#8217;t have any big headline about the development of the new storage layer. We keep collaborating with experts in our attempt to ensure solid solutions for all situations. In addition to booting experts, the input from <a href="http://www.gnu.org/software/parted/">Parted</a> guru Petr Uzel was really valuable during this sprint. We took some important decisions about the integration of the new libstorage and libparted and we made progress in implementing a partitioning proposal that ensures a bootable system in all architectures and configurations, backed with highly readable tests and specs.</p>
+<p>If time and bug reports permit, we&#8217;ll have much more to show after the next sprint&#8230; but that would be in three weeks from now. Meanwhile, have a lot of fun!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/04/06/highlights-of-development-sprint-17/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>AMD Catalyst 15.12 for openSUSE – new makerpm-amd-script is available</title>
+		<link>https://lizards.opensuse.org/2016/03/17/amd-catalyst-15-12-for-opensuse-new-makerpm-amd-script-is-available/</link>
+		<comments>https://lizards.opensuse.org/2016/03/17/amd-catalyst-15-12-for-opensuse-new-makerpm-amd-script-is-available/#comments</comments>
+		<pubDate>Thu, 17 Mar 2016 18:41:13 +0000</pubDate>
+		<dc:creator><![CDATA[Sebastian Siebert]]></dc:creator>
+				<category><![CDATA[Base System]]></category>
+		<category><![CDATA[Desktop]]></category>
+		<category><![CDATA[GNOME]]></category>
+		<category><![CDATA[KDE]]></category>
+		<category><![CDATA[Kernel]]></category>
+		<category><![CDATA[Packaging]]></category>
+		<category><![CDATA[X.org]]></category>
+		<category><![CDATA[11.4]]></category>
+		<category><![CDATA[12.1]]></category>
+		<category><![CDATA[12.2]]></category>
+		<category><![CDATA[12.3]]></category>
+		<category><![CDATA[13.1]]></category>
+		<category><![CDATA[13.2]]></category>
+		<category><![CDATA[42.1]]></category>
+		<category><![CDATA[amd]]></category>
+		<category><![CDATA[ATI]]></category>
+		<category><![CDATA[driver]]></category>
+		<category><![CDATA[fglrx]]></category>
+		<category><![CDATA[Linux]]></category>
+		<category><![CDATA[openSUSE]]></category>
+		<category><![CDATA[radeon]]></category>
+		<category><![CDATA[rpm]]></category>
+		<category><![CDATA[Tumbleweed]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11773</guid>
+		<description><![CDATA[AMD has released the new AMD Catalyst 15.12 (Radeon Crimson Edition). My script replaces the existing packaging script with an updated packaging script. It supports up to Kernel 4.5. (Official support up to Kernel 3.19) Important note: The driver does not work on openSUSE Tumbleweed. Unfortunately, the version of X-server is too new for the [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>AMD has released the new AMD Catalyst 15.12 (Radeon Crimson Edition). My script replaces the existing packaging script with an updated packaging script. It supports up to Kernel 4.5. (Official support up to Kernel 3.19)</p>
+<p><strong>Important note:</strong> The driver does not work on openSUSE Tumbleweed. Unfortunately, the version of X-server is too new for the driver.</p>
+<p>SHA1 is obsolete by now. The script used SHA256 for integrity of the downloaded files.</p>
+<p>New Feature from packaging script:</p>
+<ul>
+<li>systemd support</li>
+</ul>
+<p>Resolved Issues:</p>
+<ul>
+<li>[SWDEV-82980] Ubuntu 15.10 fails when building the .deb packages</li>
+</ul>
+<p>Link: <a href="http://support.amd.com/en-us/kb-articles/Pages/AMDRadeonSoftwareCrimsonEdition15-12LINReleaseNotes.aspx">AMD Catalyst 15.12 Release Notes</a></p>
+<p>Downloads:</p>
+<ul>
+<li>Script: <a href="https://www.sebastian-siebert.de/downloads/makerpm-amd-15.12.sh" target="_blank">makerpm-amd-15.12.sh</a></li>
+<li>SHA1: <a href="https://www.sebastian-siebert.de/downloads/makerpm-amd-15.12.sh.sha256" target="_blank">makerpm-amd-15.12.sh.sha256</a></li>
+</ul>
+<p>Installation guide (English):<br />
+<a href="http://en.opensuse.org/SDB:AMD_fglrx#Building_the_rpm_yourself">http://en.opensuse.org/SDB:AMD_fglrx#Building_the_rpm_yourself</a></p>
+<p>Bruno Friedmann will build the new RPM packages in the fglrx repository. Stay tune!</p>
+<p>If you find any issue with the driver. Don’t hesitate to contact me. I am in contact with AMD and can forward your issue to the right place. Feedback are welcome.</p>
+<p>A report of your system is very helpful beside your feedback. You can generate it with the script:<br />
+<code>su -c 'sh makerpm-amd-15.12.sh -ur'</code></p>
+<p>Have a lot of fun!</p>
+<p>Sebastian<br />
+openSUSE member / Official AMD Packaging Script Maintainer for openSUSE<br />
+German Blog: <a href="https://www.sebastian-siebert.de/2016/03/17/opensuse-proprietaeren-grafik-treiber-amd-catalyst-15-12-als-rpm-installieren/">openSUSE – proprietären Grafik-Treiber AMD Catalyst 15.12 als RPM installieren</a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/03/17/amd-catalyst-15-12-for-opensuse-new-makerpm-amd-script-is-available/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 16</title>
+		<link>https://lizards.opensuse.org/2016/03/15/highlights-of-development-sprint-16/</link>
+		<comments>https://lizards.opensuse.org/2016/03/15/highlights-of-development-sprint-16/#comments</comments>
+		<pubDate>Tue, 15 Mar 2016 16:28:16 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11748</guid>
+		<description><![CDATA[After three weeks of work, another development sprint is over. So time for another report for our fellow geckos. As usual, quite some time was invested in boring bug fixes and small non-obvious improvements, but we also have some interesting stuff to talk about. Improved UI for the encrypted partitioning proposal We wanted to talk [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>After three weeks of work, another development sprint is over. So time for another report for our fellow geckos. As usual, quite some time was invested in boring bug fixes and small non-obvious improvements, but we also have some interesting stuff to talk about.</p>
+<h3>Improved UI for the encrypted partitioning proposal</h3>
+<p>We wanted to talk about this feature not only because it has a visible impact in the user interface, but also because it&#8217;s a great example of collaboration among the different roles present in a Scrum Team. Formerly our Scrum development team was only formed by the developers of the YaST Team at SUSE. For this sprint (and future ones) the Scrum Team has been powered up with the addition of Ken Wimer as UI/UX expert and Jozef Pupava, one of the openQA.opensuse.org and openQA.suse.de operators.</p>
+<p>We got a feature request to make encryption more visible in this dialog.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/28ea0408-e22b-11e5-8290-9ad25dd65776.png" rel="attachment wp-att-11753"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/28ea0408-e22b-11e5-8290-9ad25dd65776-225x300.png" alt="Old partitioning proposal dialog" width="225" height="300" class="aligncenter size-medium wp-image-11753" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/03/28ea0408-e22b-11e5-8290-9ad25dd65776-225x300.png 225w, http://lizards.opensuse.org/wp-content/uploads/2016/03/28ea0408-e22b-11e5-8290-9ad25dd65776.png 326w" sizes="(max-width: 225px) 100vw, 225px" /></a></p>
+<p>Being software developers used to tools like Vim and Git, we have to admit that the YaST team found the dialog perfectly usable and was having hard times thinking on a better alternative. Fortunately, we now have a UI/UX expert able to bring better alternatives like this one we finally implemented.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/93288588-e22b-11e5-8d9e-d6190a2ad13b.png" rel="attachment wp-att-11755"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/93288588-e22b-11e5-8d9e-d6190a2ad13b-219x300.png" alt="New dialog for partitioning proposal" width="219" height="300" class="aligncenter size-medium wp-image-11755" /></a></p>
+<p>This kind of visual changes in the installer used to cause delays in openQA, because adapting the tests while keeping the openQA machinery running is not always trivial. The great news is that it didn&#8217;t happen this time because our particular openQA superhero was already watching over our steps all along the process.</p>
+<p>So welcome into our Scrum process, Ken and Jozef!</p>
+<h3>System roles</h3>
+<p>A new feature was added to the installer making it possible to quickly adjust several settings for the installation with one shot. You can see a detailed description of the feature, including several screenshots and configurations options <a href="https://github.com/yast/yast-installation/wiki/System-Role">in this wiki page</a> at the Github repository of yast2-installation. And yes, for the impatient we also have a glorious screenshot!</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/460729c4-ea98-11e5-95e7-1a8d90729ff1.png" rel="attachment wp-att-11751"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/460729c4-ea98-11e5-95e7-1a8d90729ff1-300x231.png" alt="System Role dialog" width="300" height="231" class="aligncenter size-medium wp-image-11751" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/03/460729c4-ea98-11e5-95e7-1a8d90729ff1-300x231.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/03/460729c4-ea98-11e5-95e7-1a8d90729ff1.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Storage reimplementation: resizing partitions</h3>
+<p>We have already explained in previous reports that we are performing an integral rewrite of the code managing partitioning and other storage tasks. During this sprint, the brand new library gained the ability to resize all kind of partitions (Linux, Windows, swap, etc.). It&#8217;s nothing that is going to hit the users in the short term but at least we have a couple of screenshots to see the premiere working (yes, we know that screenshots of terminals are not the most fancy stuff).</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/shrink-vfat.png" rel="attachment wp-att-11758"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/shrink-vfat-300x195.png" alt="shrink-vfat" width="300" height="195" class="alignleft size-medium wp-image-11758" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/03/shrink-vfat-300x195.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/03/shrink-vfat.png 674w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/03/grow-ntfs.png" rel="attachment wp-att-11756"><img src="//lizards.opensuse.org/wp-content/uploads/2016/03/grow-ntfs-300x195.png" alt="grow-ntfs" width="300" height="195" class="alignright size-medium wp-image-11756" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/03/grow-ntfs-300x195.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/03/grow-ntfs.png 674w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p><br style="clear:both"></p>
+<h3 style="clear:both">Installer self-update</h3>
+<p>Starting on version 3.1.175, YaST is able to update itself during system installation. This feature will help to solve problems in the installer even after the media has been released. That&#8217;s a huge step towards improving YaST reliability.</p>
+<p>The workflow is pretty simple: during system analysis YaST will search automatically for an update. If such update is found, YaST will download, verify (using GPG) and apply it. Finally, the installation will be resumed using the new version. Nice!</p>
+<p>In the future, self update will be enabled by default. However, if for some reason you don&#8217;t want such a nice feature, you&#8217;re free to disable it. What is more: you can also craft your own update and use it instead the official one passing a custom URL to the installer.</p>
+<p>If you&#8217;re curious, you can check the <a href="https://github.com/yast/yast-installation/blob/master/doc/SELF_UPDATE.md">technical details</a>.</p>
+<h3>Storage reimplementation: the search for the perfect bootloader</h3>
+<p>One of the goals of rewriting the storage layer was to make possible to cope with all the over-complicated requirements involved in the proposal of a good bootloader configuration. This time we don&#8217;t want the different scenarios to simply pop-up over time in a bug-report-oriented basis and start aggregating more and more branches to the existing code in order to support every one of those &#8220;new&#8221; scenarios.</p>
+<p>Changes will come, for sure, but we need a solid ground based in experts knowledge to start building a flexible future-proof code to handle partitioning regarding bootloader. Thus, we started a round of contacts with several experts in all the hardware architectures supported by YaST in order to capture all the knowledge from their brains into a set of Ruby classes. It&#8217;s still a work in progress since squeezing people&#8217;s brains is not always easy, but we already have <a href="https://github.com/yast/yast-storage-ng/blob/master/doc/boot-partition.md">some preliminary document</a>.</p>
+<h3>Consolidating continuous integration tools</h3>
+<p>Continuous integration is a key aspect of software development, specially with methodologies like Scrum. Currently we use both <a href="https://travis-ci.org/">Travis</a> and <a href="http://jenkins-ci.org/">Jenkins</a> for it. Travis builds the pushed commits and pull requests at GitHub, while Jenkins takes care of the integration with the Open Build Service.</p>
+<p>We are investing quite some effort trying to use Jenkins for everything. If you want to know more about the reasons or how the progress is going, check <a href="https://github.com/yast/yast.github.io/blob/master/doc/jenkins-integration.md">the detailed documentation</a>.</p>
+<h3>And much more!</h3>
+<p>As usual, this is just a small sample of the total work delivered by the team during the latest sprint (for Scrum and statistic&#8217;s lovers, it represents 34 story points out of a total of 87 delivered ones). Hopefully enough to keep you informed&#8230; and if it&#8217;s not, you know where you can reach us for more information!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/03/15/highlights-of-development-sprint-16/feed/</wfw:commentRss>
+		<slash:comments>2</slash:comments>
+		</item>
+		<item>
+		<title>TOSprint or not to sprint?</title>
+		<link>https://lizards.opensuse.org/2016/02/27/tosprint-or-not-to-sprint/</link>
+		<comments>https://lizards.opensuse.org/2016/02/27/tosprint-or-not-to-sprint/#comments</comments>
+		<pubDate>Sat, 27 Feb 2016 18:19:44 +0000</pubDate>
+		<dc:creator><![CDATA[Bruno Friedmann]]></dc:creator>
+				<category><![CDATA[Uncategorized]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11732</guid>
+		<description><![CDATA[Report of a week of sprint TOSprint in Paris has just ended (wiki page). What a week! First of all I want to warmfully thank the sponsors, especially Olivier Courtin from Oslandia for the organization, and Mozilla France for hosting us. What is TOSprint? Once a year a bunch of hackers from projects under OsGeo [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p><img src="https://wiki.osgeo.org/images/thumb/d/d1/Logo-TOSPrint_Paris.png/900px-Logo-TOSPrint_Paris.png" alt="TOSprint Paris 2016" style="width:200px;margin:18px;float:left" /><br />
+<h2>Report of a week of sprint</h2>
+<p>TOSprint in Paris has just ended (<a href="https://wiki.osgeo.org/wiki/Paris_Code_Sprint_2016">wiki page</a>).</p>
+<p><b>What a week!</b></p>
+<p>First of all I want to warmfully thank the sponsors, especially Olivier Courtin from Oslandia for the organization, and Mozilla France for hosting us.</p>
+<h3>What is TOSprint?</h3>
+<p>Once a year a bunch of hackers from projects under OsGeo umbrella, meet in a face to face sprint.<br />
+This year it happenned in Paris with great number of participants (52).</p>
+<p>There was globally five big groups, and if each community was running its own schedule,<br />
+there was a lot of cross echanges too.</p>
+<p><a href="https://flic.kr/p/ErD5E8"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/TOSprint_Paris_Mozilla.png" alt="TOSprint Mozilla" width="600" height="187" class="aligncenter size-full wp-image-11740" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/TOSprint_Paris_Mozilla-300x94.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/TOSprint_Paris_Mozilla.png 600w" sizes="(max-width: 600px) 100vw, 600px" /><br />
+<caption>Mateusz Łoskot</caption>
+<p></a></p>
+<h3>Personal objectives</h3>
+<p>My main objective, except being enough luckly to be a sponsor, was to go there and be in direct contact with upstream.</p>
+<p>This can help a lot to improve packages, and create new ones.</p>
+<p>Moreover, as one of my openSUSE&#8217;s Application:Geo peer maintainer, Angelos Kalkas was also participating, we decided to make somes changes, and improve the situation of the repository.</p>
+<p><span id="more-11732"></span></p>
+<h3>openSUSE packaging</h3>
+<p>We were using a Staging repository to test the global changes to minimize the breakage on the main repo, kinda à la Factory <img src="https://s.w.org/images/core/emoji/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>Let&#8217;s talk about what you will get once the rebuild will finished:<br />
+<b>* gdal</b> goes to 2.0.2 which is big jump since version 1.11</p>
+<p><b>* postgis</b> got upgrade to 2.2.1 with sfcgal as dependency so 3D operations are avalaible.</p>
+<p>I added two interesting extensions for postgresql/postgis database<br />
+ <b>&#8211; pgRouting :</b> a long time missing extension in our repository. see <a href="http://pgrouting.org/">pgrouting.org</a><br />
+ <b>&#8211; pointcloud :</b> allow you to store and work with pointcloud in postgresql and also contain a postgis extension. see <a href="https://github.com/pgpointcloud/pointcloud">https://github.com/pgpointcloud/pointcloud</a><br />
+Both packages are respecting the postgresql/postgis naming scheme: so to install pointcloud on a postgresql94 server you will install postgresql94-pointcloud package.<br />
+They are available at least for 13.2, Leap 42.1, Tumbleweed.</p>
+<p>A big thanks to Paul Ramsey for his help resolving the issues raised. Especially the advise to stick to -j1 during compilation of postgis <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p><b>* PDAL <a href="http://www.pdal.io/">pdal.io</a></b> (with libght) is a point cloud abstraction layer which is under active development and should<br />
+in the future replace libLAS once the compatible C interface will be written.<br />
+  A big thanks to Howard Butler, for helping to get all packaging issues resolved.</p>
+<p><b>* Mapserver :</b> <a href="http://mapserver.org">mapserver.org</a><br />
+During the week, mapserver team made impressive changes:<br />
+ &#8211; First by closing numerous github issues which didn&#8217;t get updates for a long time.<br />
+They run a bot script which automatically close the github issue, and users get a nice message about it.<br />
+Perhaps it could inspire us, on how we write closing ticket in bugtriage.<br />
+<a href="https://www.flickr.com/photos/139706282@N06/24936988840/in/album-72157664338100169/" title="OSGeo TOSprint Paris"><img src="https://farm2.staticflickr.com/1508/24936988840_183b1b805f_n.jpg" width="320" height="213" alt="OSGeo TOSprint Paris"></a></p>
+<pre style="background:gray;color:white;font-style:italic">
+  This is an automated comment
+
+  This issue has been closed due to lack of activity. This doesn't mean the issue is invalid,
+  it simply got no attention within the last year. Please reopen with missing/relevant information
+  if still valid.
+
+  Typically, issues fall in this state for one of the following reasons:
+
+      Hard, impossible or not enough information to reproduce
+      Missing test case
+      Lack of a champion with interest and/or funding to address the issue
+</pre>
+<p> &#8211; Part of the team took the challenge to update all the tutorial material.<br />
+ &#8211; A number of question about the future of mapscript : lacking maintenance resources (humans and or funding)<br />
+ &#8211; Bugfix release on thursday night. 6.4.3 and 7.0.1</p>
+<p>For openSUSE, I&#8217;ve been discussing a lot with Thomas Bonfort.<br />
+The idea would be to be able to propose at least two or more versions that receive security and bug fixes. Actually the 6.4 and the 7.0 branches.<br />
+This will allow people to smoothly upgrade their map files, when there&#8217;s breakage or adaptation needed.</p>
+<p>I classify this request as a good idea, and started analyzing what we can do. So its actually a work in progress.</p>
+<h3>Conclusion</h3>
+<p>There&#8217;s nothing more enthusiastic (for me) than participating to a FLOSS event. If some days are more frustrating than others, the others serve to build this free world we all need.<br />
+So I would like to ping your attention : <b> all FLOSS software and communities need your contribution </b>. If you&#8217;re using one of them, become interested in how it is built, organized, start to learn today how to contribute, and enjoy your journey.</p>
+<p>There&#8217;s more to come, especially on the mapserver side, and more and more packages.<br />
+Stay tuned!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/27/tosprint-or-not-to-sprint/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 15</title>
+		<link>https://lizards.opensuse.org/2016/02/25/highlights-of-development-sprint-15/</link>
+		<comments>https://lizards.opensuse.org/2016/02/25/highlights-of-development-sprint-15/#comments</comments>
+		<pubDate>Thu, 25 Feb 2016 11:49:55 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11707</guid>
+		<description><![CDATA[We know you have missed the usual summary from the YaST trenches. But don&#8217;t panic, here you got it! As usual, we will only cover some highlights, saving you from the gory details of the not so exciting regular bugfixing. Package notifications libzypp has a nice feature that enables packages to display notifications when they’re [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>We know you have missed the usual summary from the YaST trenches. But don&#8217;t panic, here you got it! As usual, we will only cover some highlights, saving you from the gory details of the not so exciting regular bugfixing.</p>
+<h3>Package notifications</h3>
+<p>libzypp has a nice feature that enables packages to display notifications when they’re installed/upgraded. Zypper takes advantages of this feature and shows that information when a package is installed/upgraded. For example, if you install <code>mariadb</code> package, Zypper will inform you about setting up a database root password and so on.</p>
+<p>If you installed any of those packages with YaST, you missed that piece of information… until now! Starting on <code>yast2 3.1.175</code> YaST will show packages notifications.</p>
+<p><img class="aligncenter" src="https://cloud.githubusercontent.com/assets/15836/13257232/e7e23058-da45-11e5-8e7d-b116f47c686c.png" alt="installation-messages-qt" /></p>
+<p><img class="aligncenter" src="https://cloud.githubusercontent.com/assets/15836/13257235/ea6ecade-da45-11e5-91ff-579cb257b859.png" alt="installation-messages-ncurses" /></p>
+<p>The only exception is when doing a regular installation (or autoinstallation), as we want to show as few dialogs as possible.</p>
+<h3>Registration Codes from a USB Stick</h3>
+<p>During the installation of a SUSE Linux Enterprise product, you are asked for a registration code. Previously you had to remember it and type it by hand. Now the code can be read from USB storage.</p>
+<p><img src="https://cloud.githubusercontent.com/assets/102056/13245125/4e0bf5de-da0b-11e5-839a-9d8d70052149.png" alt="regcode-from-usb" /><br />
+<img src="https://cloud.githubusercontent.com/assets/102056/13255345/127cc83c-da46-11e5-97b5-bc6365361cfd.png" alt="regcode-from-usb-extensions" /></p>
+<p>Insert a USB stick at installation boot time or at the latest before you proceed from the first installation screen (Language, Keyboard and License Agreement). That stick should contain the registration codes either at <code>/regcodes.txt</code> or at <code>/regcodes.xml</code>. In the registration dialogs, the input fields will be prefilled.</p>
+<p>The syntax of the files is as follows. In the file identify the product with the name quoted by <code>zypper search --type product</code> or <code>SUSEConnect --list-extensions</code> (without the /version/architecture part).</p>
+<p>regcodes.txt:
+<pre>
+SLES    cc36aae1
+SLED    309105d4
+
+sle-we  5eedd26a
+sle-live-patching 8c541494
+</pre>
+<p>regcodes.xml: (xml wins if both xml and txt are present)
+<pre>
+&lt;?xml version="1.0"?&gt;
+&lt;profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns"&gt;
+  &lt;suse_register&gt;
+    &lt;!-- See https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Register.Extension --&gt;
+    &lt;addons config:type="list"&gt;
+      &lt;addon&gt;
+        &lt;!-- Name of add-on as listed by "zypper search --type product" --&gt;
+        &lt;name&gt;sle-we&lt;/name&gt;
+        &lt;reg_code&gt;5eedd26a&lt;/reg_code&gt;
+      &lt;/addon&gt;
+      &lt;addon&gt;
+        &lt;name&gt;sle-live-patching&lt;/name&gt;
+        &lt;reg_code&gt;8c541494&lt;/reg_code&gt;
+      &lt;/addon&gt;
+      &lt;addon&gt;
+        &lt;!-- SLES is not an add-on but listing it here allows for combining
+             several base product registration codes in a single file --&gt;
+        &lt;name&gt;SLES&lt;/name&gt;
+        &lt;reg_code&gt;cc36aae1&lt;/reg_code&gt;
+      &lt;/addon&gt;
+      &lt;addon&gt;
+        &lt;name&gt;SLED&lt;/name&gt;
+        &lt;reg_code&gt;309105d4&lt;/reg_code&gt;
+      &lt;/addon&gt;
+    &lt;/addons&gt;
+  &lt;/suse_register&gt;
+&lt;/profile&gt;
+</pre>
+<p></p>
+<h3>Lot of Btrfs-related improvements in the expert partitioner</h3>
+<p>We also invested quite some time improving the support for Btrfs in the expert partitioner. Implementing one requested feature and closing five bugs.</p>
+<p>The following animation shows the feature #320296 (user friendly handling of subvolumes) in action, together with the fix to 965279 (Btrfs settings always overridden with default values).</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/subvolumes-opt.gif" alt="subvolumes-opt" class="aligncenter" /></a></p>
+<p>But we have even more screenshots and animations for the improvements in the expert partitioner. In the description of <a href="https://github.com/yast/yast-storage/pull/190">this pull request</a>, you have screenshots displaying the new dialog that was implemented to fix bug#928641. And in <a href="https://github.com/yast/yast-storage/pull/186">this other pull request</a>, you can see in action the fixes for bug#944252 (snapshots were offered for partitions other than root) and for bug#954691 (fstab options being forgotten for Btrfs partitions).</p>
+<h3>Improving testability of the new storage code</h3>
+<p>In recent posts, we reported how we are about to refactor the storage subsystem of YaST. The improved partition proposal for installation <a href="https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/">presented in the previous summary</a> performs a lot of operations &#8211;  like analyzing what disks are there and what is on each one of them, checking if there already is enough free space and making a best guess on what partitions may be candidates to be removed to make space for a new Linux installation.</p>
+<p>If there are many disks with many partitions, this can get complicated really quickly. So we need a reliable way to test it. Thus, we created a testing framework to build fake storage hardware (disks) with fake partitions and file systems. Although it&#8217;s fake hardware (we can&#8217;t create hard disks out of thin air&#8230; yet), it enables us to do unit tests without setting up virtual machines. With those tests we can cover a lot more scenarios that would otherwise be really difficult to test, with one or many disks, with many partitions of different kinds, with a previously existing RAID array or whatever.</p>
+<p>One nice thing about the new libstorage is that it operates on &#8220;device graphs&#8221; that can be transformed into the GraphViz format for easy visualization. Here you have a nice diagram generated by libstorage based on some fake hardware created from <a href="https://gist.github.com/ancorgs/014c34c3c74b9949f3a2">this YAML specification</a>.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs.png" rel="attachment wp-att-11723"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs-300x136.png" alt="fake-devicegraphs" width="300" height="136" class="aligncenter size-medium wp-image-11723" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs-300x136.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs.png 763w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Better handling of wrong registration code for extensions</h3>
+<p>We also spent some time improving the usability of the section for registration of extensions and modules. Now if the user selects several modules and the registration of some of them fails, the user will be kindly redirected back to the same dialog but only with inputs for the unregistered ones. From there, they can go back to unselect the failing extensions or retry with different (or even with the same) codes.</p>
+<h3>Say goodbye to the &#8220;receive system mail&#8221; checkbox</h3>
+<p>As the last step of the improvements done to the user creation dialog (see the <a href="https://lizards.opensuse.org/?p=11673">previous post</a> for more details). We removed the long-ago meaningless checkbox titled &#8220;Receive System Mail&#8221;. That leaded to the removal of quite some code&#8230; and removing code is usually a good thing. <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<h3>Many other things</h3>
+<p>As usual, this is just a short summary with some highlights. Many other stuff was implemented and several other bugs were fixed but, you know, we cannot blog about everything if we want to invest some time in debugging and coding. <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>See you in the highlights for next sprint, in around three weeks.</p>
+<p>PS.- If you want to be part of the fun, take a look to the YaST-related summer projects we have on the <a href="http://101.opensuse.org/">openSUSE mentoring page</a>.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/25/highlights-of-development-sprint-15/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Sugar on openSUSE</title>
+		<link>https://lizards.opensuse.org/2016/02/17/sugar-on-opensuse/</link>
+		<comments>https://lizards.opensuse.org/2016/02/17/sugar-on-opensuse/#respond</comments>
+		<pubDate>Wed, 17 Feb 2016 14:25:18 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Desktop]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[Packaging]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11705</guid>
+		<description><![CDATA[Built openSUSE Leap based Sugar test images on SUSE Studio, get it from here. If you wish to get involved with the project maintaining packages, fixing/reporting bugs, follow the links on the X11:Sugar build service project page.]]></description>
+				<content:encoded><![CDATA[<p>Built openSUSE Leap based <a href="https://www.sugarlabs.org/">Sugar</a> test images on SUSE Studio, <a href="https://susestudio.com/a/F78UZ4/sugarsuse-leap-42-1">get it from here</a>.</p>
+<p>If you wish to get involved with the project maintaining packages, fixing/reporting bugs, follow the links on the <a href="https://build.opensuse.org/project/show/X11:Sugar">X11:Sugar</a> build service project page.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/17/sugar-on-opensuse/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 14</title>
+		<link>https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/</link>
+		<comments>https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/#comments</comments>
+		<pubDate>Wed, 03 Feb 2016 08:08:15 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11673</guid>
+		<description><![CDATA[Another three weeks period and another report from the YaST Team (if you don&#8217;t know what we are talking about, see highlights of sprint 13 and the presentation post). This was actually a very productive sprint although, as usual, not all changes have such an obvious impact on final users, at least in the short [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Another three weeks period and another report from the YaST Team (if you don&#8217;t know what we are talking about, see <a href="https://lizards.opensuse.org/2016/01/07/highlights-of-development-sprint-13/">highlights of sprint 13</a> and the <a href="https://lizards.opensuse.org/2015/12/15/lets-blog-about-yast/">presentation post</a>). This was actually a very productive sprint although, as usual, not all changes have such an obvious impact on final users, at least in the short term.</p>
+<h3>Redesign and refactoring of the user creation dialog</h3>
+<p>One of the most visible changes, at least during the installation process, is the revamped dialog for creating local users. There is a full screenshots-packed description of the original problems (at usability and code levels) and the implemented solution in the <a href="https://github.com/yast/yast-users/pull/84">description of this pull request</a> at Github.com.</p>
+<p>Spoilers: the new dialog looks like the screenshot below and the openSUSE community now needs to decide the default behavior we want for Tumbleweed regarding password encryption methods. To take part in that discussion, read the mentioned description and reply to <a href="http://lists.opensuse.org/opensuse-factory/2016-01/msg00496.html">this thread</a> in the openSUSE Factory mailing list.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4.png" rel="attachment wp-att-11675"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4-300x225.png" alt="b12a8f90-c51b-11e5-9ceb-659b6c77bac4" width="300" height="225" class="aligncenter size-medium wp-image-11675" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Beyond the obvious changes for the final user, the implementation of the new dialogs resulted in a much cleaner and more tested code base, including a new <a href="http://www.rubydoc.info/github/yast/yast-yast2/UI/InstallationDialog">reusable class</a> to greatly streamline the development of new installation dialogs in the future.</p>
+<h3>One step further in the new libstorage: installation proposal</h3>
+<p>In the highlights of the previous sprint, we already explained the YaST team is putting a lot of effort in rewriting the layer that access to disks, partitions, volumes and all that. One important milestone in such rewrite is the ability to examine a hard disk with a complex partitioning schema (including MS Windows partitions, a Linux installation and so on) and propose the operations that need to be performed in order to install (open)SUSE. It&#8217;s a more complex topic that it could look at the first glance.</p>
+<p>During this sprint we created a command line tool that can perform that task. Is still not part of the installation process and will take quite some time until it gets there, but it&#8217;s already a nice showcase of the capabilities of the new library.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1.png" rel="attachment wp-att-11682"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1.png" alt="new-storage-proposal-2016-01-27-1900" width="738" height="636" class="aligncenter size-full wp-image-11682" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1-300x259.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1.png 738w" sizes="(max-width: 738px) 100vw, 738px" /></a><br />
+</p>
+<h3>Fixed a crash when EULA download fails</h3>
+<p>If a download error occurred during the installation of any module or extension requiring an EULA, YaST simply exited after displaying a pop-up error, as you can see here.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/0c444926-bb75-11e5-8e6e-029d018c14d3.gif" rel="attachment wp-att-11684"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/0c444926-bb75-11e5-8e6e-029d018c14d3.gif" alt="0c444926-bb75-11e5-8e6e-029d018c14d3" width="700" height="616" class="aligncenter size-full wp-image-11684" /></a></p>
+<p>Now the workflow goes back to the extension selection, to retry or to deselect the problematic extension. Just like this.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/46fb22a6-bb75-11e5-9830-aff1d516e77e.gif" rel="attachment wp-att-11686"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/46fb22a6-bb75-11e5-9830-aff1d516e77e.gif" alt="46fb22a6-bb75-11e5-9830-aff1d516e77e" width="702" height="623" class="aligncenter size-full wp-image-11686" /></a></p>
+<p></p>
+<h3>Continuous integration for Snapper and (the current) libstorage</h3>
+<p><a href="https://github.com/openSUSE/snapper">Snapper</a> and <a href="https://github.com/openSUSE/libstorage/">libstorage</a> now build the Git “master” branch continuously on <a href="http://ci.opensuse.org">ci.opensuse.org</a> (<a href="https://ci.opensuse.org/job/snapper-master/">S</a>, <a href="https://ci.opensuse.org/job/libstorage-master/">L</a>), and commit a passing build to the OBS development project (<a href="https://build.opensuse.org/package/show/YaST:Head/snapper">S</a>, <a href="https://build.opensuse.org/package/show/YaST:Head/libstorage">L</a>), and if the version number has changed, submit the package to Factory (<a href="https://build.opensuse.org/package/show/openSUSE:Factory/snapper">S</a>, <a href="https://build.opensuse.org/package/show/openSUSE:Factory/libstorage">L</a>).</p>
+<p>The same set-up works on <a href="http://ci.suse.de">ci.suse.de</a> (<a href="https://ci.suse.de/job/snapper-master/">S</a>, <a href="https://ci.suse.de/job/libstorage-master/">L</a>), committing to the SUSE&#8217;s internal OBS instance (<a href="https://build.suse.de/package/show/Devel:YaST:Head/snapper">S</a>, <a href="https://build.suse.de/package/show/Devel:YaST:Head/libstorage">L</a>) and submitting to the future SLE12-SP2 (<a href="https://build.suse.de/package/show/SUSE:SLE-12-SP2:GA/snapper">S</a>, <a href="https://build.suse.de/package/show/SUSE:SLE-12-SP2:GA/libstorage">L</a>).</p>
+<p>This brings these two packages up to the level of automation that the YaST team uses for the yast2-* packages, and allows releasing simple fixes even by team members who do not work on these packages regularly.</p>
+<h3>Disk usage stats in installation and software manager: do not list subvolumes</h3>
+<p>While installing software, YaST provides a visual overview of the free space in the different mount points of the system. With Btrfs and its subvolumes feature, the separation between a physical disk and its mount point is not that clear anymore. That resulted in wrong reports in YaST, like the one displayed in the left bottom corner of this screen.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage.png" rel="attachment wp-att-11695"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage.png" alt="broken-disk-usage" width="681" height="468" class="aligncenter size-full wp-image-11695" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage-300x206.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage.png 681w" sizes="(max-width: 681px) 100vw, 681px" /></a></p>
+<p>The actual calculation of free space is performed by libzypp (the Zypper library), YaST only takes care of rendering the result of that calculation in the screen. Thus, we closely collaborated with the Zypper developer, Michael Andres, to teach libzypp how to deal with Btrfs subvolumes. Thanks to his work, with any version of libzypp &gt;= 15.21 (already available in Tumbleweed), you can enjoy an error-free disk usage report.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage.png" rel="attachment wp-att-11696"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage.png" alt="fixed-disk-usage" width="681" height="468" class="aligncenter size-full wp-image-11696" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage-300x206.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage.png 681w" sizes="(max-width: 681px) 100vw, 681px" /></a></p>
+<p>To ensure we have no regressions, the YaST team also contributed a new test to openQA. See it <a href="https://openqa.opensuse.org/tests/117876/modules/yast2_i/steps/7">in action</a>.</p>
+<h3>Cleanup dependencies in YaST systemd services</h3>
+<p>We have received several bug reports about problems executing AutoYaST or YasT2-Firstboot in combination with complex network settings or third party services&#8230; and even in some simple scenarios. Many of these problems boil down to a single culprit &#8211; the dependencies of the YaST related systemd units.</p>
+<p>During this sprint we have simplified the unit files for Tumbleweed and SLE, as you can see in <a href="https://github.com/yast/yast-installation/pull/332/files">this pull request</a>. It&#8217;s a small change but with a huge impact and several implications, so a lot of time was invested into testing during the sprint. The problems seem to be gone, but more AutoYaST and YaST-Firstboot testing would be highly appreciated.</p>
+<h3>Many other things</h3>
+<p>As usual, this is only a brief collection of highlights of all the job done during the sprint. Using Scrum terminology, this represents only 27 story points out of a total of 81 story points delivered by the team during this sprint. Using more mundane words, this is just a third part of what we have achieved during the last three weeks.</p>
+<p>Hopefully, enough to keep you entertained until the next report in other three weeks!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/feed/</wfw:commentRss>
+		<slash:comments>3</slash:comments>
+		</item>
+		<item>
+		<title>Running live image from RAM</title>
+		<link>https://lizards.opensuse.org/2016/01/29/running-live-image-from-ram/</link>
+		<comments>https://lizards.opensuse.org/2016/01/29/running-live-image-from-ram/#respond</comments>
+		<pubDate>Fri, 29 Jan 2016 10:31:41 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Education]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11671</guid>
+		<description><![CDATA[Some time back I wrote a patch to KIWI that allows running openSUSE live entirely from RAM(tmpfs). How to use it? Pass &#8220;toram&#8221; parameter at the boot menu. Try it on Li-f-e. Benefits: Running the OS from RAM make it lot more responsive than running from DVD or USB device, for example it is most [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Some time back I wrote a patch to KIWI that allows running openSUSE live entirely from RAM(tmpfs).<br />
+<span id="more-11671"></span></p>
+<p>How to use it?<br />
+Pass &#8220;toram&#8221; parameter at the boot menu. Try it on <a href="https://en.opensuse.org/openSUSE:Education-Li-f-e">Li-f-e</a>.</p>
+<p>Benefits:<br />
+Running the OS from RAM make it lot more responsive than running from DVD or USB device, for example it is most useful for running a demo computer where many users try lot of applications installed in the live system. USB or the DVD can be ejected once the OS is loaded. It can be used to load OS to RAM directly from iso in a virtual machine as well.</p>
+<p>Caveat:<br />
+Needs enough RAM to copy the entire iso to RAM and then some spare to operate the OS, Li-f-e for instance would need minimum 5G RAM available. It also takes a bit longer to boot as the entire image is copied to RAM.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/01/29/running-live-image-from-ram/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>A brief 360° overview of my first board turn</title>
+		<link>https://lizards.opensuse.org/2016/01/18/a-brief-360-overview-of-my-first-board-turn/</link>
+		<comments>https://lizards.opensuse.org/2016/01/18/a-brief-360-overview-of-my-first-board-turn/#comments</comments>
+		<pubDate>Mon, 18 Jan 2016 18:00:31 +0000</pubDate>
+		<dc:creator><![CDATA[Bruno Friedmann]]></dc:creator>
+				<category><![CDATA[Board]]></category>
+		<category><![CDATA[Elections]]></category>
+		<category><![CDATA[openSUSE]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11647</guid>
+		<description><![CDATA[You&#8217;ve certainly noticed that I didn&#8217;t run for a second turn, after my first 2 years. This doesn&#8217;t mean the election time and the actual campaign are boring If you are an openSUSE Member, we really want to have your vote, so go to Board Election Wiki and make your own opinion. The ballot should [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>
+You&#8217;ve certainly noticed that I didn&#8217;t run for a second turn, after my first 2 years. This doesn&#8217;t mean the election time and the actual campaign are boring <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /><br />
+<br />If you are an openSUSE Member, we really want to have your vote, so go to <a href="https://en.opensuse.org/openSUSE:Board_election">Board Election Wiki</a> and make your own opinion.<br />
+<br />The ballot should open tomorrow.
+</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/board-leaving-tigerfoot.png" alt="board-leaving-tigerfoot" width="370" height="262" class="alignleft size-full wp-image-11655" style="margin: 0px 20px 20px 0px" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/01/board-leaving-tigerfoot-300x212.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/01/board-leaving-tigerfoot.png 370w" sizes="(max-width: 370px) 100vw, 370px" /></p>
+<h3>Why not a second turn?</h3>
+<p>Being a board member (present at almost every conference call, reading the mailing lists and other task) consume free time. It has increased during the last semester too. And we&#8217;ve got some new business opportunities here at Ioda-Net Sàrl in 2015, and those need also my attention for the next year(s). I prefer to be a retired Board member, than not being able to handle my responsabilities.<br />
+But I&#8217;m not against the idea of a <i>&quot;I&#8217;ll be back&quot;</i> in a near future. Moreover with a bit more bandwidth in my free time, I will be able to continue my packaging stuff, and other contributions.
+</p>
+<h3 style="clear:both">What a journey!</h3>
+<p>With the new campaign running, I found funny to bring back to light my <a href="https://en.opensuse.org/openSUSE:Board_election_platform_2013_tigerfoot">2013 platform</a> written 2 years ago. And spent 5 minutes on checking the differences with today. I&#8217;m inviting you to discover the small interview between me and myself <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" />
+</p>
+<h4>1. Which sentences would you say again today?</h4>
+<p>I&#8217;m a &quot;Fucking Green Dreamer&quot; of a world of collaboration, which will one day offer Freedom for everyone.<br />
+<br />Clearly still a day by day mantra and leitmotiv. But even if I&#8217;m dreaming, I never forget that<br />
+<b>Freedom has a price : Freedom will only be what you do for it.</b>
+</p>
+<p><span id="more-11647"></span></p>
+<h4>2. Which thing you would not say again, or differently ?</h4>
+<p>Well, as there&#8217;s no joker card, let&#8217;s start by this one:<br />
+&quot;A Visible Active Board &gt; A Visible Active Project.&quot; With the experience and time, and interaction, (the one who said fight, get out please :-)), I would said this is not as easy as it sound first.<br />
+I&#8217;m pretty sure, I was more quieter since I was on the board, than before. Because it&#8217;s too hard to make a clear distinction, when you just want to express something as &quot;a simple contributor&quot;: you are on the board, and then whatever you can try to trick the fact: you&#8217;re still a board member.<br />
+<br />So making the Board visible like a kind of communicant Alien, will certainly not improve that much our project.<br />
+It&#8217;s written everywhere, almost everybody agree, the board is not the lighthouse in the dark showing you the future.<br />
+Anyone, I repeat, anyone in this community is a potential vector of a future for openSUSE.
+</p>
+<p>So in my past platform &quot;Guardians of the past, Managers of the present, Creators of the future.&quot; I would replace Creators of the future by kinda &quot;enabler&quot;</p>
+<h4>3. In the last 2 years, where did openSUSE mostly evolve?</h4>
+<p>I think we moved from a traditional way of building distribution to some creative alternative, the rolling but tested Tumbleweed, and the hybrid Leap are really good things that happened.<br />
+I believe that if we have also some hard time on mailing list, which are exhausting, they also have a positive aspect (yeap:-)). If we fight, then it&#8217;s certainly because of our faith in something. Is this one defined? Not sure! But I&#8217;m pretty convinced that all members around have a good image of it.
+</p>
+<h4>4. What would be an advice to your successor (even if he doesn&#8217;t care about it)?</h4>
+<p>We are a tooling community, we love tools. Beware of one thing, if you get hurt by a tool, you can become the worst asshole you&#8217;ve never met. With tools, you can also hurt other people.
+</p>
+<p>My advise, watch your step and keystroke!</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/truly-green-yours.png" alt="truly-green-yours" width="230" height="217" class="alignleft size-full wp-image-11667" style="margin: 0px 20px 20px 0px" /></p>
+<h4>5. Something more you would like to share?</h4>
+<p>I&#8217;ve invested time and energy during 2014 and beginning of 2015, to run booth, talks, represent openSUSE&#8217;s project all around. It was awesome to go to those events and meet people, involved or interested about openSUSE.<br />
+<br /> Perhaps some of you don&#8217;t know, but we have friends all around us, in many communities, and when the magic about working together appears, it just blast my heart.
+</p>
+<p>Thanks for reading and for your support during this period</p>
+<p><b>Truly green yours</b></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/01/18/a-brief-360-overview-of-my-first-board-turn/feed/</wfw:commentRss>
+		<slash:comments>8</slash:comments>
+		</item>
+		<item>
+		<title>Li-f-e at BITA Show 2016</title>
+		<link>https://lizards.opensuse.org/2016/01/10/li-f-e-at-bita-show-2016/</link>
+		<pubDate>Sun, 10 Jan 2016 07:19:18 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Ambassadors]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[Marketing]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11642</guid>
+		<description><![CDATA[BITA IT Show, the biggest IT exhibition in western India is coming to town on 24-26 January, We will be there promoting Li-f-e. If you are in this part of the world, drop in to check it out.]]></description>
+				<content:encoded><![CDATA[<p><a href="http://bitaindia.org/" target="_blank">BITA IT Show</a>, the biggest IT exhibition in western India is coming to town on 24-26 January, We will be there promoting <a href="https://en.opensuse.org/openSUSE:Education-Li-f-e" target="_blank">Li-f-e</a>. If you are in this part of the world, drop in to check it out.<br />
+<a href="//lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE.jpg"><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE-212x300.jpg" alt="bita_a4_size_brochure_2016_FRONT_SIDE" width="212" height="300" class="aligncenter size-medium wp-image-11643" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE-212x300.jpg 212w, http://lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE-724x1024.jpg 724w" sizes="(max-width: 212px) 100vw, 212px" /></a></p>
+]]></content:encoded>
+			</item>
+	</channel>
+</rss>

--- a/jekyll/feed4.xml
+++ b/jekyll/feed4.xml
@@ -1,0 +1,463 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	>
+
+<channel>
+	<title>openSUSE Lizards</title>
+	<atom:link href="https://lizards.opensuse.org/feed/" rel="self" type="application/rss+xml" />
+	<link>https://lizards.opensuse.org</link>
+	<description>Blogs and Ramblings of the openSUSE Members</description>
+	<lastBuildDate>Sat, 27 Feb 2016 18:19:44 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>hourly</sy:updatePeriod>
+	<sy:updateFrequency>1</sy:updateFrequency>
+	<generator>https://wordpress.org/?v=4.4.2</generator>
+	<item>
+		<title>TOSprint or not to sprint?</title>
+		<link>https://lizards.opensuse.org/2016/02/27/tosprint-or-not-to-sprint/</link>
+		<comments>https://lizards.opensuse.org/2016/02/27/tosprint-or-not-to-sprint/#comments</comments>
+		<pubDate>Sat, 27 Feb 2016 18:19:44 +0000</pubDate>
+		<dc:creator><![CDATA[Bruno Friedmann]]></dc:creator>
+				<category><![CDATA[Uncategorized]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11732</guid>
+		<description><![CDATA[Report of a week of sprint TOSprint in Paris has just ended (wiki page). What a week! First of all I want to warmfully thank the sponsors, especially Olivier Courtin from Oslandia for the organization, and Mozilla France for hosting us. What is TOSprint? Once a year a bunch of hackers from projects under OsGeo [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p><img src="https://wiki.osgeo.org/images/thumb/d/d1/Logo-TOSPrint_Paris.png/900px-Logo-TOSPrint_Paris.png" alt="TOSprint Paris 2016" style="width:200px;margin:18px;float:left" /><br />
+<h2>Report of a week of sprint</h2>
+<p>TOSprint in Paris has just ended (<a href="https://wiki.osgeo.org/wiki/Paris_Code_Sprint_2016">wiki page</a>).</p>
+<p><b>What a week!</b></p>
+<p>First of all I want to warmfully thank the sponsors, especially Olivier Courtin from Oslandia for the organization, and Mozilla France for hosting us.</p>
+<h3>What is TOSprint?</h3>
+<p>Once a year a bunch of hackers from projects under OsGeo umbrella, meet in a face to face sprint.<br />
+This year it happenned in Paris with great number of participants (52).</p>
+<p>There was globally five big groups, and if each community was running its own schedule,<br />
+there was a lot of cross echanges too.</p>
+<p><a href="https://flic.kr/p/ErD5E8"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/TOSprint_Paris_Mozilla.png" alt="TOSprint Mozilla" width="600" height="187" class="aligncenter size-full wp-image-11740" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/TOSprint_Paris_Mozilla-300x94.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/TOSprint_Paris_Mozilla.png 600w" sizes="(max-width: 600px) 100vw, 600px" /><br />
+<caption>Mateusz Łoskot</caption>
+<p></a></p>
+<h3>Personal objectives</h3>
+<p>My main objective, except being enough luckly to be a sponsor, was to go there and be in direct contact with upstream.</p>
+<p>This can help a lot to improve packages, and create new ones.</p>
+<p>Moreover, as one of my openSUSE&#8217;s Application:Geo peer maintainer, Angelos Kalkas was also participating, we decided to make somes changes, and improve the situation of the repository.</p>
+<p><span id="more-11732"></span></p>
+<h3>openSUSE packaging</h3>
+<p>We were using a Staging repository to test the global changes to minimize the breakage on the main repo, kinda à la Factory <img src="https://s.w.org/images/core/emoji/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>Let&#8217;s talk about what you will get once the rebuild will finished:<br />
+<b>* gdal</b> goes to 2.0.2 which is big jump since version 1.11</p>
+<p><b>* postgis</b> got upgrade to 2.2.1 with sfcgal as dependency so 3D operations are avalaible.</p>
+<p>I added two interesting extensions for postgresql/postgis database<br />
+ <b>&#8211; pgRouting :</b> a long time missing extension in our repository. see <a href="http://pgrouting.org/">pgrouting.org</a><br />
+ <b>&#8211; pointcloud :</b> allow you to store and work with pointcloud in postgresql and also contain a postgis extension. see <a href="https://github.com/pgpointcloud/pointcloud">https://github.com/pgpointcloud/pointcloud</a><br />
+Both packages are respecting the postgresql/postgis naming scheme: so to install pointcloud on a postgresql94 server you will install postgresql94-pointcloud package.<br />
+They are available at least for 13.2, Leap 42.1, Tumbleweed.</p>
+<p>A big thanks to Paul Ramsey for his help resolving the issues raised. Especially the advise to stick to -j1 during compilation of postgis <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p><b>* PDAL <a href="http://www.pdal.io/">pdal.io</a></b> (with libght) is a point cloud abstraction layer which is under active development and should<br />
+in the future replace libLAS once the compatible C interface will be written.<br />
+  A big thanks to Howard Butler, for helping to get all packaging issues resolved.</p>
+<p><b>* Mapserver :</b> <a href="http://mapserver.org">mapserver.org</a><br />
+During the week, mapserver team made impressive changes:<br />
+ &#8211; First by closing numerous github issues which didn&#8217;t get updates for a long time.<br />
+They run a bot script which automatically close the github issue, and users get a nice message about it.<br />
+Perhaps it could inspire us, on how we write closing ticket in bugtriage.<br />
+<a href="https://www.flickr.com/photos/139706282@N06/24936988840/in/album-72157664338100169/" title="OSGeo TOSprint Paris"><img src="https://farm2.staticflickr.com/1508/24936988840_183b1b805f_n.jpg" width="320" height="213" alt="OSGeo TOSprint Paris"></a></p>
+<pre style="background:gray;color:white;font-style:italic">
+  This is an automated comment
+
+  This issue has been closed due to lack of activity. This doesn't mean the issue is invalid,
+  it simply got no attention within the last year. Please reopen with missing/relevant information
+  if still valid.
+
+  Typically, issues fall in this state for one of the following reasons:
+
+      Hard, impossible or not enough information to reproduce
+      Missing test case
+      Lack of a champion with interest and/or funding to address the issue
+</pre>
+<p> &#8211; Part of the team took the challenge to update all the tutorial material.<br />
+ &#8211; A number of question about the future of mapscript : lacking maintenance resources (humans and or funding)<br />
+ &#8211; Bugfix release on thursday night. 6.4.3 and 7.0.1</p>
+<p>For openSUSE, I&#8217;ve been discussing a lot with Thomas Bonfort.<br />
+The idea would be to be able to propose at least two or more versions that receive security and bug fixes. Actually the 6.4 and the 7.0 branches.<br />
+This will allow people to smoothly upgrade their map files, when there&#8217;s breakage or adaptation needed.</p>
+<p>I classify this request as a good idea, and started analyzing what we can do. So its actually a work in progress.</p>
+<h3>Conclusion</h3>
+<p>There&#8217;s nothing more enthusiastic (for me) than participating to a FLOSS event. If some days are more frustrating than others, the others serve to build this free world we all need.<br />
+So I would like to ping your attention : <b> all FLOSS software and communities need your contribution </b>. If you&#8217;re using one of them, become interested in how it is built, organized, start to learn today how to contribute, and enjoy your journey.</p>
+<p>There&#8217;s more to come, especially on the mapserver side, and more and more packages.<br />
+Stay tuned!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/27/tosprint-or-not-to-sprint/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 15</title>
+		<link>https://lizards.opensuse.org/2016/02/25/highlights-of-development-sprint-15/</link>
+		<comments>https://lizards.opensuse.org/2016/02/25/highlights-of-development-sprint-15/#comments</comments>
+		<pubDate>Thu, 25 Feb 2016 11:49:55 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11707</guid>
+		<description><![CDATA[We know you have missed the usual summary from the YaST trenches. But don&#8217;t panic, here you got it! As usual, we will only cover some highlights, saving you from the gory details of the not so exciting regular bugfixing. Package notifications libzypp has a nice feature that enables packages to display notifications when they’re [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>We know you have missed the usual summary from the YaST trenches. But don&#8217;t panic, here you got it! As usual, we will only cover some highlights, saving you from the gory details of the not so exciting regular bugfixing.</p>
+<h3>Package notifications</h3>
+<p>libzypp has a nice feature that enables packages to display notifications when they’re installed/upgraded. Zypper takes advantages of this feature and shows that information when a package is installed/upgraded. For example, if you install <code>mariadb</code> package, Zypper will inform you about setting up a database root password and so on.</p>
+<p>If you installed any of those packages with YaST, you missed that piece of information… until now! Starting on <code>yast2 3.1.175</code> YaST will show packages notifications.</p>
+<p><img class="aligncenter" src="https://cloud.githubusercontent.com/assets/15836/13257232/e7e23058-da45-11e5-8e7d-b116f47c686c.png" alt="installation-messages-qt" /></p>
+<p><img class="aligncenter" src="https://cloud.githubusercontent.com/assets/15836/13257235/ea6ecade-da45-11e5-91ff-579cb257b859.png" alt="installation-messages-ncurses" /></p>
+<p>The only exception is when doing a regular installation (or autoinstallation), as we want to show as few dialogs as possible.</p>
+<h3>Registration Codes from a USB Stick</h3>
+<p>During the installation of a SUSE Linux Enterprise product, you are asked for a registration code. Previously you had to remember it and type it by hand. Now the code can be read from USB storage.</p>
+<p><img src="https://cloud.githubusercontent.com/assets/102056/13245125/4e0bf5de-da0b-11e5-839a-9d8d70052149.png" alt="regcode-from-usb" /><br />
+<img src="https://cloud.githubusercontent.com/assets/102056/13255345/127cc83c-da46-11e5-97b5-bc6365361cfd.png" alt="regcode-from-usb-extensions" /></p>
+<p>Insert a USB stick at installation boot time or at the latest before you proceed from the first installation screen (Language, Keyboard and License Agreement). That stick should contain the registration codes either at <code>/regcodes.txt</code> or at <code>/regcodes.xml</code>. In the registration dialogs, the input fields will be prefilled.</p>
+<p>The syntax of the files is as follows. In the file identify the product with the name quoted by <code>zypper search --type product</code> or <code>SUSEConnect --list-extensions</code> (without the /version/architecture part).</p>
+<p>regcodes.txt:
+<pre>
+SLES    cc36aae1
+SLED    309105d4
+
+sle-we  5eedd26a
+sle-live-patching 8c541494
+</pre>
+<p>regcodes.xml: (xml wins if both xml and txt are present)
+<pre>
+&lt;?xml version="1.0"?&gt;
+&lt;profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns"&gt;
+  &lt;suse_register&gt;
+    &lt;!-- See https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Register.Extension --&gt;
+    &lt;addons config:type="list"&gt;
+      &lt;addon&gt;
+        &lt;!-- Name of add-on as listed by "zypper search --type product" --&gt;
+        &lt;name&gt;sle-we&lt;/name&gt;
+        &lt;reg_code&gt;5eedd26a&lt;/reg_code&gt;
+      &lt;/addon&gt;
+      &lt;addon&gt;
+        &lt;name&gt;sle-live-patching&lt;/name&gt;
+        &lt;reg_code&gt;8c541494&lt;/reg_code&gt;
+      &lt;/addon&gt;
+      &lt;addon&gt;
+        &lt;!-- SLES is not an add-on but listing it here allows for combining
+             several base product registration codes in a single file --&gt;
+        &lt;name&gt;SLES&lt;/name&gt;
+        &lt;reg_code&gt;cc36aae1&lt;/reg_code&gt;
+      &lt;/addon&gt;
+      &lt;addon&gt;
+        &lt;name&gt;SLED&lt;/name&gt;
+        &lt;reg_code&gt;309105d4&lt;/reg_code&gt;
+      &lt;/addon&gt;
+    &lt;/addons&gt;
+  &lt;/suse_register&gt;
+&lt;/profile&gt;
+</pre>
+<p></p>
+<h3>Lot of Btrfs-related improvements in the expert partitioner</h3>
+<p>We also invested quite some time improving the support for Btrfs in the expert partitioner. Implementing one requested feature and closing five bugs.</p>
+<p>The following animation shows the feature #320296 (user friendly handling of subvolumes) in action, together with the fix to 965279 (Btrfs settings always overridden with default values).</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/subvolumes-opt.gif" alt="subvolumes-opt" class="aligncenter" /></a></p>
+<p>But we have even more screenshots and animations for the improvements in the expert partitioner. In the description of <a href="https://github.com/yast/yast-storage/pull/190">this pull request</a>, you have screenshots displaying the new dialog that was implemented to fix bug#928641. And in <a href="https://github.com/yast/yast-storage/pull/186">this other pull request</a>, you can see in action the fixes for bug#944252 (snapshots were offered for partitions other than root) and for bug#954691 (fstab options being forgotten for Btrfs partitions).</p>
+<h3>Improving testability of the new storage code</h3>
+<p>In recent posts, we reported how we are about to refactor the storage subsystem of YaST. The improved partition proposal for installation <a href="https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/">presented in the previous summary</a> performs a lot of operations &#8211;  like analyzing what disks are there and what is on each one of them, checking if there already is enough free space and making a best guess on what partitions may be candidates to be removed to make space for a new Linux installation.</p>
+<p>If there are many disks with many partitions, this can get complicated really quickly. So we need a reliable way to test it. Thus, we created a testing framework to build fake storage hardware (disks) with fake partitions and file systems. Although it&#8217;s fake hardware (we can&#8217;t create hard disks out of thin air&#8230; yet), it enables us to do unit tests without setting up virtual machines. With those tests we can cover a lot more scenarios that would otherwise be really difficult to test, with one or many disks, with many partitions of different kinds, with a previously existing RAID array or whatever.</p>
+<p>One nice thing about the new libstorage is that it operates on &#8220;device graphs&#8221; that can be transformed into the GraphViz format for easy visualization. Here you have a nice diagram generated by libstorage based on some fake hardware created from <a href="https://gist.github.com/ancorgs/014c34c3c74b9949f3a2">this YAML specification</a>.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs.png" rel="attachment wp-att-11723"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs-300x136.png" alt="fake-devicegraphs" width="300" height="136" class="aligncenter size-medium wp-image-11723" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs-300x136.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/fake-devicegraphs.png 763w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Better handling of wrong registration code for extensions</h3>
+<p>We also spent some time improving the usability of the section for registration of extensions and modules. Now if the user selects several modules and the registration of some of them fails, the user will be kindly redirected back to the same dialog but only with inputs for the unregistered ones. From there, they can go back to unselect the failing extensions or retry with different (or even with the same) codes.</p>
+<h3>Say goodbye to the &#8220;receive system mail&#8221; checkbox</h3>
+<p>As the last step of the improvements done to the user creation dialog (see the <a href="https://lizards.opensuse.org/?p=11673">previous post</a> for more details). We removed the long-ago meaningless checkbox titled &#8220;Receive System Mail&#8221;. That leaded to the removal of quite some code&#8230; and removing code is usually a good thing. <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<h3>Many other things</h3>
+<p>As usual, this is just a short summary with some highlights. Many other stuff was implemented and several other bugs were fixed but, you know, we cannot blog about everything if we want to invest some time in debugging and coding. <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /></p>
+<p>See you in the highlights for next sprint, in around three weeks.</p>
+<p>PS.- If you want to be part of the fun, take a look to the YaST-related summer projects we have on the <a href="http://101.opensuse.org/">openSUSE mentoring page</a>.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/25/highlights-of-development-sprint-15/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		</item>
+		<item>
+		<title>Sugar on openSUSE</title>
+		<link>https://lizards.opensuse.org/2016/02/17/sugar-on-opensuse/</link>
+		<comments>https://lizards.opensuse.org/2016/02/17/sugar-on-opensuse/#respond</comments>
+		<pubDate>Wed, 17 Feb 2016 14:25:18 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Desktop]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[Packaging]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11705</guid>
+		<description><![CDATA[Built openSUSE Leap based Sugar test images on SUSE Studio, get it from here. If you wish to get involved with the project maintaining packages, fixing/reporting bugs, follow the links on the X11:Sugar build service project page.]]></description>
+				<content:encoded><![CDATA[<p>Built openSUSE Leap based <a href="https://www.sugarlabs.org/">Sugar</a> test images on SUSE Studio, <a href="https://susestudio.com/a/F78UZ4/sugarsuse-leap-42-1">get it from here</a>.</p>
+<p>If you wish to get involved with the project maintaining packages, fixing/reporting bugs, follow the links on the <a href="https://build.opensuse.org/project/show/X11:Sugar">X11:Sugar</a> build service project page.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/17/sugar-on-opensuse/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 14</title>
+		<link>https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/</link>
+		<comments>https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/#comments</comments>
+		<pubDate>Wed, 03 Feb 2016 08:08:15 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11673</guid>
+		<description><![CDATA[Another three weeks period and another report from the YaST Team (if you don&#8217;t know what we are talking about, see highlights of sprint 13 and the presentation post). This was actually a very productive sprint although, as usual, not all changes have such an obvious impact on final users, at least in the short [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Another three weeks period and another report from the YaST Team (if you don&#8217;t know what we are talking about, see <a href="https://lizards.opensuse.org/2016/01/07/highlights-of-development-sprint-13/">highlights of sprint 13</a> and the <a href="https://lizards.opensuse.org/2015/12/15/lets-blog-about-yast/">presentation post</a>). This was actually a very productive sprint although, as usual, not all changes have such an obvious impact on final users, at least in the short term.</p>
+<h3>Redesign and refactoring of the user creation dialog</h3>
+<p>One of the most visible changes, at least during the installation process, is the revamped dialog for creating local users. There is a full screenshots-packed description of the original problems (at usability and code levels) and the implemented solution in the <a href="https://github.com/yast/yast-users/pull/84">description of this pull request</a> at Github.com.</p>
+<p>Spoilers: the new dialog looks like the screenshot below and the openSUSE community now needs to decide the default behavior we want for Tumbleweed regarding password encryption methods. To take part in that discussion, read the mentioned description and reply to <a href="http://lists.opensuse.org/opensuse-factory/2016-01/msg00496.html">this thread</a> in the openSUSE Factory mailing list.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4.png" rel="attachment wp-att-11675"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4-300x225.png" alt="b12a8f90-c51b-11e5-9ceb-659b6c77bac4" width="300" height="225" class="aligncenter size-medium wp-image-11675" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4-300x225.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4-768x576.png 768w, http://lizards.opensuse.org/wp-content/uploads/2016/02/b12a8f90-c51b-11e5-9ceb-659b6c77bac4.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Beyond the obvious changes for the final user, the implementation of the new dialogs resulted in a much cleaner and more tested code base, including a new <a href="http://www.rubydoc.info/github/yast/yast-yast2/UI/InstallationDialog">reusable class</a> to greatly streamline the development of new installation dialogs in the future.</p>
+<h3>One step further in the new libstorage: installation proposal</h3>
+<p>In the highlights of the previous sprint, we already explained the YaST team is putting a lot of effort in rewriting the layer that access to disks, partitions, volumes and all that. One important milestone in such rewrite is the ability to examine a hard disk with a complex partitioning schema (including MS Windows partitions, a Linux installation and so on) and propose the operations that need to be performed in order to install (open)SUSE. It&#8217;s a more complex topic that it could look at the first glance.</p>
+<p>During this sprint we created a command line tool that can perform that task. Is still not part of the installation process and will take quite some time until it gets there, but it&#8217;s already a nice showcase of the capabilities of the new library.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1.png" rel="attachment wp-att-11682"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1.png" alt="new-storage-proposal-2016-01-27-1900" width="738" height="636" class="aligncenter size-full wp-image-11682" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1-300x259.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/new-storage-proposal-2016-01-27-1900-1.png 738w" sizes="(max-width: 738px) 100vw, 738px" /></a><br />
+</p>
+<h3>Fixed a crash when EULA download fails</h3>
+<p>If a download error occurred during the installation of any module or extension requiring an EULA, YaST simply exited after displaying a pop-up error, as you can see here.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/0c444926-bb75-11e5-8e6e-029d018c14d3.gif" rel="attachment wp-att-11684"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/0c444926-bb75-11e5-8e6e-029d018c14d3.gif" alt="0c444926-bb75-11e5-8e6e-029d018c14d3" width="700" height="616" class="aligncenter size-full wp-image-11684" /></a></p>
+<p>Now the workflow goes back to the extension selection, to retry or to deselect the problematic extension. Just like this.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/46fb22a6-bb75-11e5-9830-aff1d516e77e.gif" rel="attachment wp-att-11686"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/46fb22a6-bb75-11e5-9830-aff1d516e77e.gif" alt="46fb22a6-bb75-11e5-9830-aff1d516e77e" width="702" height="623" class="aligncenter size-full wp-image-11686" /></a></p>
+<p></p>
+<h3>Continuous integration for Snapper and (the current) libstorage</h3>
+<p><a href="https://github.com/openSUSE/snapper">Snapper</a> and <a href="https://github.com/openSUSE/libstorage/">libstorage</a> now build the Git “master” branch continuously on <a href="http://ci.opensuse.org">ci.opensuse.org</a> (<a href="https://ci.opensuse.org/job/snapper-master/">S</a>, <a href="https://ci.opensuse.org/job/libstorage-master/">L</a>), and commit a passing build to the OBS development project (<a href="https://build.opensuse.org/package/show/YaST:Head/snapper">S</a>, <a href="https://build.opensuse.org/package/show/YaST:Head/libstorage">L</a>), and if the version number has changed, submit the package to Factory (<a href="https://build.opensuse.org/package/show/openSUSE:Factory/snapper">S</a>, <a href="https://build.opensuse.org/package/show/openSUSE:Factory/libstorage">L</a>).</p>
+<p>The same set-up works on <a href="http://ci.suse.de">ci.suse.de</a> (<a href="https://ci.suse.de/job/snapper-master/">S</a>, <a href="https://ci.suse.de/job/libstorage-master/">L</a>), committing to the SUSE&#8217;s internal OBS instance (<a href="https://build.suse.de/package/show/Devel:YaST:Head/snapper">S</a>, <a href="https://build.suse.de/package/show/Devel:YaST:Head/libstorage">L</a>) and submitting to the future SLE12-SP2 (<a href="https://build.suse.de/package/show/SUSE:SLE-12-SP2:GA/snapper">S</a>, <a href="https://build.suse.de/package/show/SUSE:SLE-12-SP2:GA/libstorage">L</a>).</p>
+<p>This brings these two packages up to the level of automation that the YaST team uses for the yast2-* packages, and allows releasing simple fixes even by team members who do not work on these packages regularly.</p>
+<h3>Disk usage stats in installation and software manager: do not list subvolumes</h3>
+<p>While installing software, YaST provides a visual overview of the free space in the different mount points of the system. With Btrfs and its subvolumes feature, the separation between a physical disk and its mount point is not that clear anymore. That resulted in wrong reports in YaST, like the one displayed in the left bottom corner of this screen.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage.png" rel="attachment wp-att-11695"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage.png" alt="broken-disk-usage" width="681" height="468" class="aligncenter size-full wp-image-11695" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage-300x206.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/broken-disk-usage.png 681w" sizes="(max-width: 681px) 100vw, 681px" /></a></p>
+<p>The actual calculation of free space is performed by libzypp (the Zypper library), YaST only takes care of rendering the result of that calculation in the screen. Thus, we closely collaborated with the Zypper developer, Michael Andres, to teach libzypp how to deal with Btrfs subvolumes. Thanks to his work, with any version of libzypp &gt;= 15.21 (already available in Tumbleweed), you can enjoy an error-free disk usage report.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage.png" rel="attachment wp-att-11696"><img src="//lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage.png" alt="fixed-disk-usage" width="681" height="468" class="aligncenter size-full wp-image-11696" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage-300x206.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/02/fixed-disk-usage.png 681w" sizes="(max-width: 681px) 100vw, 681px" /></a></p>
+<p>To ensure we have no regressions, the YaST team also contributed a new test to openQA. See it <a href="https://openqa.opensuse.org/tests/117876/modules/yast2_i/steps/7">in action</a>.</p>
+<h3>Cleanup dependencies in YaST systemd services</h3>
+<p>We have received several bug reports about problems executing AutoYaST or YasT2-Firstboot in combination with complex network settings or third party services&#8230; and even in some simple scenarios. Many of these problems boil down to a single culprit &#8211; the dependencies of the YaST related systemd units.</p>
+<p>During this sprint we have simplified the unit files for Tumbleweed and SLE, as you can see in <a href="https://github.com/yast/yast-installation/pull/332/files">this pull request</a>. It&#8217;s a small change but with a huge impact and several implications, so a lot of time was invested into testing during the sprint. The problems seem to be gone, but more AutoYaST and YaST-Firstboot testing would be highly appreciated.</p>
+<h3>Many other things</h3>
+<p>As usual, this is only a brief collection of highlights of all the job done during the sprint. Using Scrum terminology, this represents only 27 story points out of a total of 81 story points delivered by the team during this sprint. Using more mundane words, this is just a third part of what we have achieved during the last three weeks.</p>
+<p>Hopefully, enough to keep you entertained until the next report in other three weeks!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/02/03/highlights-of-development-sprint-14/feed/</wfw:commentRss>
+		<slash:comments>3</slash:comments>
+		</item>
+		<item>
+		<title>Running live image from RAM</title>
+		<link>https://lizards.opensuse.org/2016/01/29/running-live-image-from-ram/</link>
+		<comments>https://lizards.opensuse.org/2016/01/29/running-live-image-from-ram/#respond</comments>
+		<pubDate>Fri, 29 Jan 2016 10:31:41 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Education]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11671</guid>
+		<description><![CDATA[Some time back I wrote a patch to KIWI that allows running openSUSE live entirely from RAM(tmpfs). How to use it? Pass &#8220;toram&#8221; parameter at the boot menu. Try it on Li-f-e. Benefits: Running the OS from RAM make it lot more responsive than running from DVD or USB device, for example it is most [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Some time back I wrote a patch to KIWI that allows running openSUSE live entirely from RAM(tmpfs).<br />
+<span id="more-11671"></span></p>
+<p>How to use it?<br />
+Pass &#8220;toram&#8221; parameter at the boot menu. Try it on <a href="https://en.opensuse.org/openSUSE:Education-Li-f-e">Li-f-e</a>.</p>
+<p>Benefits:<br />
+Running the OS from RAM make it lot more responsive than running from DVD or USB device, for example it is most useful for running a demo computer where many users try lot of applications installed in the live system. USB or the DVD can be ejected once the OS is loaded. It can be used to load OS to RAM directly from iso in a virtual machine as well.</p>
+<p>Caveat:<br />
+Needs enough RAM to copy the entire iso to RAM and then some spare to operate the OS, Li-f-e for instance would need minimum 5G RAM available. It also takes a bit longer to boot as the entire image is copied to RAM.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/01/29/running-live-image-from-ram/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>A brief 360° overview of my first board turn</title>
+		<link>https://lizards.opensuse.org/2016/01/18/a-brief-360-overview-of-my-first-board-turn/</link>
+		<comments>https://lizards.opensuse.org/2016/01/18/a-brief-360-overview-of-my-first-board-turn/#comments</comments>
+		<pubDate>Mon, 18 Jan 2016 18:00:31 +0000</pubDate>
+		<dc:creator><![CDATA[Bruno Friedmann]]></dc:creator>
+				<category><![CDATA[Board]]></category>
+		<category><![CDATA[Elections]]></category>
+		<category><![CDATA[openSUSE]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11647</guid>
+		<description><![CDATA[You&#8217;ve certainly noticed that I didn&#8217;t run for a second turn, after my first 2 years. This doesn&#8217;t mean the election time and the actual campaign are boring If you are an openSUSE Member, we really want to have your vote, so go to Board Election Wiki and make your own opinion. The ballot should [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>
+You&#8217;ve certainly noticed that I didn&#8217;t run for a second turn, after my first 2 years. This doesn&#8217;t mean the election time and the actual campaign are boring <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" /><br />
+<br />If you are an openSUSE Member, we really want to have your vote, so go to <a href="https://en.opensuse.org/openSUSE:Board_election">Board Election Wiki</a> and make your own opinion.<br />
+<br />The ballot should open tomorrow.
+</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/board-leaving-tigerfoot.png" alt="board-leaving-tigerfoot" width="370" height="262" class="alignleft size-full wp-image-11655" style="margin: 0px 20px 20px 0px" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/01/board-leaving-tigerfoot-300x212.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/01/board-leaving-tigerfoot.png 370w" sizes="(max-width: 370px) 100vw, 370px" /></p>
+<h3>Why not a second turn?</h3>
+<p>Being a board member (present at almost every conference call, reading the mailing lists and other task) consume free time. It has increased during the last semester too. And we&#8217;ve got some new business opportunities here at Ioda-Net Sàrl in 2015, and those need also my attention for the next year(s). I prefer to be a retired Board member, than not being able to handle my responsabilities.<br />
+But I&#8217;m not against the idea of a <i>&quot;I&#8217;ll be back&quot;</i> in a near future. Moreover with a bit more bandwidth in my free time, I will be able to continue my packaging stuff, and other contributions.
+</p>
+<h3 style="clear:both">What a journey!</h3>
+<p>With the new campaign running, I found funny to bring back to light my <a href="https://en.opensuse.org/openSUSE:Board_election_platform_2013_tigerfoot">2013 platform</a> written 2 years ago. And spent 5 minutes on checking the differences with today. I&#8217;m inviting you to discover the small interview between me and myself <img src="https://lizards.opensuse.org/wp-includes/images/smilies/simple-smile.png" alt=":-)" class="wp-smiley" style="height: 1em; max-height: 1em;" />
+</p>
+<h4>1. Which sentences would you say again today?</h4>
+<p>I&#8217;m a &quot;Fucking Green Dreamer&quot; of a world of collaboration, which will one day offer Freedom for everyone.<br />
+<br />Clearly still a day by day mantra and leitmotiv. But even if I&#8217;m dreaming, I never forget that<br />
+<b>Freedom has a price : Freedom will only be what you do for it.</b>
+</p>
+<p><span id="more-11647"></span></p>
+<h4>2. Which thing you would not say again, or differently ?</h4>
+<p>Well, as there&#8217;s no joker card, let&#8217;s start by this one:<br />
+&quot;A Visible Active Board &gt; A Visible Active Project.&quot; With the experience and time, and interaction, (the one who said fight, get out please :-)), I would said this is not as easy as it sound first.<br />
+I&#8217;m pretty sure, I was more quieter since I was on the board, than before. Because it&#8217;s too hard to make a clear distinction, when you just want to express something as &quot;a simple contributor&quot;: you are on the board, and then whatever you can try to trick the fact: you&#8217;re still a board member.<br />
+<br />So making the Board visible like a kind of communicant Alien, will certainly not improve that much our project.<br />
+It&#8217;s written everywhere, almost everybody agree, the board is not the lighthouse in the dark showing you the future.<br />
+Anyone, I repeat, anyone in this community is a potential vector of a future for openSUSE.
+</p>
+<p>So in my past platform &quot;Guardians of the past, Managers of the present, Creators of the future.&quot; I would replace Creators of the future by kinda &quot;enabler&quot;</p>
+<h4>3. In the last 2 years, where did openSUSE mostly evolve?</h4>
+<p>I think we moved from a traditional way of building distribution to some creative alternative, the rolling but tested Tumbleweed, and the hybrid Leap are really good things that happened.<br />
+I believe that if we have also some hard time on mailing list, which are exhausting, they also have a positive aspect (yeap:-)). If we fight, then it&#8217;s certainly because of our faith in something. Is this one defined? Not sure! But I&#8217;m pretty convinced that all members around have a good image of it.
+</p>
+<h4>4. What would be an advice to your successor (even if he doesn&#8217;t care about it)?</h4>
+<p>We are a tooling community, we love tools. Beware of one thing, if you get hurt by a tool, you can become the worst asshole you&#8217;ve never met. With tools, you can also hurt other people.
+</p>
+<p>My advise, watch your step and keystroke!</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/truly-green-yours.png" alt="truly-green-yours" width="230" height="217" class="alignleft size-full wp-image-11667" style="margin: 0px 20px 20px 0px" /></p>
+<h4>5. Something more you would like to share?</h4>
+<p>I&#8217;ve invested time and energy during 2014 and beginning of 2015, to run booth, talks, represent openSUSE&#8217;s project all around. It was awesome to go to those events and meet people, involved or interested about openSUSE.<br />
+<br /> Perhaps some of you don&#8217;t know, but we have friends all around us, in many communities, and when the magic about working together appears, it just blast my heart.
+</p>
+<p>Thanks for reading and for your support during this period</p>
+<p><b>Truly green yours</b></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/01/18/a-brief-360-overview-of-my-first-board-turn/feed/</wfw:commentRss>
+		<slash:comments>8</slash:comments>
+		</item>
+		<item>
+		<title>Li-f-e at BITA Show 2016</title>
+		<link>https://lizards.opensuse.org/2016/01/10/li-f-e-at-bita-show-2016/</link>
+		<comments>https://lizards.opensuse.org/2016/01/10/li-f-e-at-bita-show-2016/#respond</comments>
+		<pubDate>Sun, 10 Jan 2016 07:19:18 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Ambassadors]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[Marketing]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11642</guid>
+		<description><![CDATA[BITA IT Show, the biggest IT exhibition in western India is coming to town on 24-26 January, We will be there promoting Li-f-e. If you are in this part of the world, drop in to check it out.]]></description>
+				<content:encoded><![CDATA[<p><a href="http://bitaindia.org/" target="_blank">BITA IT Show</a>, the biggest IT exhibition in western India is coming to town on 24-26 January, We will be there promoting <a href="https://en.opensuse.org/openSUSE:Education-Li-f-e" target="_blank">Li-f-e</a>. If you are in this part of the world, drop in to check it out.<br />
+<a href="//lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE.jpg"><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE-212x300.jpg" alt="bita_a4_size_brochure_2016_FRONT_SIDE" width="212" height="300" class="aligncenter size-medium wp-image-11643" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE-212x300.jpg 212w, http://lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE-724x1024.jpg 724w" sizes="(max-width: 212px) 100vw, 212px" /></a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/01/10/li-f-e-at-bita-show-2016/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 13</title>
+		<link>https://lizards.opensuse.org/2016/01/07/highlights-of-development-sprint-13/</link>
+		<comments>https://lizards.opensuse.org/2016/01/07/highlights-of-development-sprint-13/#respond</comments>
+		<pubDate>Thu, 07 Jan 2016 12:43:35 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11630</guid>
+		<description><![CDATA[As promised in the previous post on this blog, we&#8217;ll try to keep you updated about what is happening in the YaST world. Before Christmas we finished an specially short sprint, interrupted by another successful Hackweek. Although we always reserve some time for bug fixing, the last two sprints has been quite focused in looking [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>As promised in the <a href="https://lizards.opensuse.org/2015/12/15/lets-blog-about-yast/">previous post</a> on this blog, we&#8217;ll try to keep you updated about what is happening in the YaST world. Before Christmas we finished an specially short sprint, interrupted by <a href="https://en.opensuse.org/Portal:Hackweek">another successful Hackweek</a>. Although we always reserve some time for bug fixing, the last two sprints has been quite focused in looking into the future, implementing new solutions for old problems and trying to prepare replacements for some legacy stuff we have been carrying on for too long. Here you are the highlights.</p>
+<h3>SCR replacement</h3>
+<p>For low level access to the system, YaST uses its own library called SCR, inherited from the old YCP days. It&#8217;s used to call scripts and also to read and write files. Its design is showing its age and using it from Ruby is unnecessary complex. We feel SCR is one of the biggest source of confusion for newcomers to YaST development. Last but not least, SCR is only used by YaST which means all the maintenance work fall to us.</p>
+<p>We want to use a new approach for the future. For running scripts we plan to use a Ruby gem called <a href="https://github.com/openSUSE/cheetah">Cheetah</a> and for accessing configuration files we plan to rely on <a href="http://augeas.net/">Augeas</a>.</p>
+<p>Taking some improvements that were needed in YaST2-Bootloader and the drop of perl-bootloader as starting points (or as an excuse, if you prefer), we have used this sprint to develop all the moving parts that will allow us to easily use Cheetah and Augeas within YaST.</p>
+<p>For Cheetah, we have contributed two features to the upstream project: <a href="https://github.com/openSUSE/cheetah/pull/33">chroot support</a> and the ability to provide <a href="https://github.com/openSUSE/cheetah/pull/32">environment variables</a>.</p>
+<p>For Augeas we have developed an object oriented layer called <a href="https://github.com/config-files-api/config_files_api">Config Files Api</a> (shortly CFA). The idea of CFA is to provide specific functionality by mean of plugins. Of course, the <a href="https://github.com/config-files-api/config_files_api_grub2">first plugin</a> we have developed is aimed to manipulation of all the Grub2 configuration files.</p>
+<p>The next step will be to integrate these new components into the next versions of YaST2-Bootloader, hitting your Tumbleweed repositories soon. Of course, after all the usual manual and openQA testing.</p>
+<h3>Libstorage replacement</h3>
+<p>Another low level layer that has been a constant source of headache for YaST developers is libstorage. We use it -specially in the installer and the partitioner- to access disks, partitions, volumes and all that. Once again, the original design have fundamental flaws that limit us in many ways and we have been dreaming for quite some time about writing a replacement for it.</p>
+<p>To make this rewrite fit into the Scrum process, we are using the new redesigned library (find the code <a href="https://github.com/openSUSE/libstorage-bgl-eval">at Github</a> and the packages <a href="https://build.opensuse.org/package/show/home:aschnell:storage-redesign/libstorage">at OBS</a>) to write prototypes for the installer partitioning proposal and for a new partitioning YaST module.</p>
+<p>This new module is only intended as a testbed to showcase the development of the new library and to drive its integration process. It&#8217;s not intended for end users, but after this sprint it can already do some things that are impossible with the current partitioner and even shows some nice graphs really useful for debugging and verifying the behavior of the library.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/01/action-graph.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/action-graph-300x219.png" alt="Libstorage Tech Preview: action graph" width="300" height="219" class="aligncenter size-medium wp-image-11634" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/01/action-graph-300x219.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/01/action-graph.png 816w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>If you don&#8217;t mind to break your system using unsupported software, you can always fetch <a href="https://github.com/aschnell/yast-storage-ng">the code</a> or <a href="https://build.opensuse.org/package/show/home:aschnell:storage-redesign/yast2-storage-ng">the packages</a>.</p>
+<h3>AutoYaST integration tests</h3>
+<p>Testing is crucial in software development. And integration tests are a must when you are developing an installer. During the last sprints, we have been developing and improving our own solution for testing AutoYaST-driven installations, consisting on a set of tests and a framework to run them.</p>
+<p>The goal for this sprint was to de-couple the tests and the framework. Making it possible to reuse our tests in openQA. As a side effect, we wanted to ease the installation and usage of our testing framework.</p>
+<p>Both goals were achieved, now you can install AutoYaST Integration Tests (not a very original name) following <a href="https://github.com/yast/autoyast-integration-test">the instructions</a> available in the repository and there is already an openQA instance directly running <a href="https://github.com/yast/aytests-tests">the separately available tests</a>.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/01/aytests-help.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/aytests-help-300x78.png" alt="aytests-help" width="300" height="78" class="aligncenter size-medium wp-image-11639" srcset="http://lizards.opensuse.org/wp-content/uploads/2016/01/aytests-help-300x78.png 300w, http://lizards.opensuse.org/wp-content/uploads/2016/01/aytests-help.png 765w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Snapper development documentation</h3>
+<p>Last but not least, as a side effect of the development (and the Scrum principles), we have improved the Snapper&#8217;s development documentation. Enjoy it at <a href="https://github.com/openSUSE/snapper">the usual Snapper repository</a>.</p>
+<p>That&#8217;s all folks. Next sprint starts next week and will be three weeks long, so expect more news during the first days of February.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/01/07/highlights-of-development-sprint-13/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Live ISO Multi-boot USB revisited &#8211; live-grub-stick</title>
+		<link>https://lizards.opensuse.org/2015/12/25/live-iso-multi-boot-usb-revisited-live-grub-stick/</link>
+		<comments>https://lizards.opensuse.org/2015/12/25/live-iso-multi-boot-usb-revisited-live-grub-stick/#respond</comments>
+		<pubDate>Fri, 25 Dec 2015 09:31:48 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[Usability]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11624</guid>
+		<description><![CDATA[Earlier tool live-fat-stick uses syslinux to create multiboot USB stick/hdd on a vfat parition without having to format the stick preserving existing data and copying whole ISO so the same stick can serve as demo as well as to copy ISOs for distributing. However the disadvantages are all of them that comes from using vfat. [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Earlier tool <a href="https://lizards.opensuse.org/2012/09/13/live-fat-stick/">live-fat-stick</a> uses syslinux to create multiboot USB stick/hdd on a vfat parition without having to format the stick preserving existing data and copying whole ISO so the same stick can serve as demo as well as to copy ISOs for distributing. However the disadvantages are all of them that comes from using vfat.</p>
+<p>Grub2 has come a long way and almost all major distributions now support booting from the iso image via loopback. So here is <a href="https://software.opensuse.org/package/live-grub-stick">live-grub-stick</a> script that uses grub in place of syslinux bringing in all the advantages of using grub2.</p>
+<p>Currently live images of openSUSE, Ubuntu, Fedora and all their clones are supported. Go ahead and <a href="https://github.com/cyberorg/live-fat-stick">fork it</a> if you would like to add support for your distribution.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/12/25/live-iso-multi-boot-usb-revisited-live-grub-stick/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Announcing Li-f-e 42.1</title>
+		<link>https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/</link>
+		<comments>https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/#comments</comments>
+		<pubDate>Mon, 21 Dec 2015 10:37:48 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Architectures]]></category>
+		<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Desktop]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[GNOME]]></category>
+		<category><![CDATA[KDE]]></category>
+		<category><![CDATA[Mono]]></category>
+		<category><![CDATA[Network]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Server]]></category>
+		<category><![CDATA[Usability]]></category>
+		<category><![CDATA[Classroom]]></category>
+		<category><![CDATA[Graphic designing]]></category>
+		<category><![CDATA[LTSP]]></category>
+		<category><![CDATA[Multimedia]]></category>
+		<category><![CDATA[openSUSE]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11596</guid>
+		<description><![CDATA[The best Linux distribution for education got a whole lot better, your Li-f-e(Linux for Education) takes a &#8220;Leap&#8221; to 42.1. openSUSE Education community is proud to present this latest edition based on openSUSE 42.1 with all the features, updates and bug fixes available on it till date. This effectively makes it the only enterprise grade [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>The best Linux distribution for education got a whole lot better, your <a href="https://en.opensuse.org/openSUSE:Education-Li-f-e">Li-f-e(Linux for Education)</a> takes a &#8220;<a href="https://news.opensuse.org/2015/11/04/opensuse-leap-42-1-becomes-first-hybrid-distribution/">Leap</a>&#8221; to 42.1. <a href="https://en.opensuse.org/Education">openSUSE Education</a> community is proud to present this latest edition based on <a href="https://en.opensuse.org/Portal:42.1">openSUSE 42.1</a> with all the features, updates and bug fixes available on it till date. This effectively makes it the only enterprise grade long term supported(LTS) distribution for Education.</p>
+<p>As with previous releases <a href="http://download.opensuse-education.org/~cyberorg/opensuse-edu-life-4211-packages.txt">we have bundled a ton of softwares</a> on this <a href="https://en.opensuse.org/Live_USB_stick">live DVD/USB</a> specially packaged for education, along with the Plasma, GNOME and Mate Desktop Environments, full multimedia experience is also provided out of the box thanks to the Packman repositories. Only x86_64 architecture is supported, if you have a lot of machines that only support x86 then read on to find out how you can extend their Li-f-e.<br />
+<span id="more-11596"></span></p>
+<p>You can of course very <a href="http://cyberorg.github.io/kiwi-ltsp-howto/">easily turn Li-f-e to full-fledged LTSP server</a> to PXE boot machines in your local network. Booting both i686 and x86_64 architectures is supported. In case you need to PXE boot machines below i686 then you would have to <a href="https://software.opensuse.org/package/kiwi-ltsp-tinycore-tc">install this package</a>.</p>
+<p>Happy holidays!</p>
+
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot7/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot7-150x150.png" class="attachment-thumbnail size-thumbnail" alt="Games" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot8/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot8-150x150.png" class="attachment-thumbnail size-thumbnail" alt="Development" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot10/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot10-150x150.png" class="attachment-thumbnail size-thumbnail" alt="Graphics" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot16/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot16-150x150.png" class="attachment-thumbnail size-thumbnail" alt="Learning" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot15/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot15-150x150.png" class="attachment-thumbnail size-thumbnail" alt="Learning" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot12/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot12-150x150.png" class="attachment-thumbnail size-thumbnail" alt="Multimedia" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot11/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot11-150x150.png" class="attachment-thumbnail size-thumbnail" alt="Office" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/screenshot-from-2015-12-20-16-41-37/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/Screenshot-from-2015-12-20-16-41-37-150x150.png" class="attachment-thumbnail size-thumbnail" alt="Mate desktop" /></a>
+
+<p>Get Li-f-e from here: <a href="http://sourceforge.net/projects/opensuse-edu/files/download/ISOs/openSUSE-Edu-li-f-e.x86_64-42.1.1.iso/download">Direct Download</a> | <a href="http://sourceforge.net/projects/opensuse-edu/files/download/ISOs/openSUSE-Edu-li-f-e.x86_64-42.1.1.iso.md5/download">md5sum</a> | <a href="http://download.opensuse-education.org/ISOs/">Alternate download and mirrors</a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/feed/</wfw:commentRss>
+		<slash:comments>5</slash:comments>
+		</item>
+	</channel>
+</rss>

--- a/jekyll/feed5.xml
+++ b/jekyll/feed5.xml
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	>
+
+<channel>
+	<title>openSUSE Lizards</title>
+	<atom:link href="https://lizards.opensuse.org/feed/" rel="self" type="application/rss+xml" />
+	<link>https://lizards.opensuse.org</link>
+	<description>Blogs and Ramblings of the openSUSE Members</description>
+	<lastBuildDate>Sun, 10 Jan 2016 07:19:18 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>hourly</sy:updatePeriod>
+	<sy:updateFrequency>1</sy:updateFrequency>
+	<generator>http://wordpress.org/?v=4.2.4</generator>
+	<item>
+		<title>Li-f-e at BITA Show 2016</title>
+		<link>https://lizards.opensuse.org/2016/01/10/li-f-e-at-bita-show-2016/</link>
+		<comments>https://lizards.opensuse.org/2016/01/10/li-f-e-at-bita-show-2016/#comments</comments>
+		<pubDate>Sun, 10 Jan 2016 07:19:18 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Ambassadors]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[Marketing]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11642</guid>
+		<description><![CDATA[BITA IT Show, the biggest IT exhibition in western India is coming to town on 24-26 January, We will be there promoting Li-f-e. If you are in this part of the world, drop in to check it out.]]></description>
+				<content:encoded><![CDATA[<p><a href="http://bitaindia.org/" target="_blank">BITA IT Show</a>, the biggest IT exhibition in western India is coming to town on 24-26 January, We will be there promoting <a href="https://en.opensuse.org/openSUSE:Education-Li-f-e" target="_blank">Li-f-e</a>. If you are in this part of the world, drop in to check it out.<br />
+<a href="//lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE.jpg"><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/bita_a4_size_brochure_2016_FRONT_SIDE-212x300.jpg" alt="bita_a4_size_brochure_2016_FRONT_SIDE" width="212" height="300" class="aligncenter size-medium wp-image-11643" /></a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/01/10/li-f-e-at-bita-show-2016/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Highlights of development sprint 13</title>
+		<link>https://lizards.opensuse.org/2016/01/07/highlights-of-development-sprint-13/</link>
+		<comments>https://lizards.opensuse.org/2016/01/07/highlights-of-development-sprint-13/#comments</comments>
+		<pubDate>Thu, 07 Jan 2016 12:43:35 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[YaST]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11630</guid>
+		<description><![CDATA[As promised in the previous post on this blog, we&#8217;ll try to keep you updated about what is happening in the YaST world. Before Christmas we finished an specially short sprint, interrupted by another successful Hackweek. Although we always reserve some time for bug fixing, the last two sprints has been quite focused in looking [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>As promised in the <a href="https://lizards.opensuse.org/2015/12/15/lets-blog-about-yast/">previous post</a> on this blog, we&#8217;ll try to keep you updated about what is happening in the YaST world. Before Christmas we finished an specially short sprint, interrupted by <a href="https://en.opensuse.org/Portal:Hackweek">another successful Hackweek</a>. Although we always reserve some time for bug fixing, the last two sprints has been quite focused in looking into the future, implementing new solutions for old problems and trying to prepare replacements for some legacy stuff we have been carrying on for too long. Here you are the highlights.</p>
+<h3>SCR replacement</h3>
+<p>For low level access to the system, YaST uses its own library called SCR, inherited from the old YCP days. It&#8217;s used to call scripts and also to read and write files. Its design is showing its age and using it from Ruby is unnecessary complex. We feel SCR is one of the biggest source of confusion for newcomers to YaST development. Last but not least, SCR is only used by YaST which means all the maintenance work fall to us.</p>
+<p>We want to use a new approach for the future. For running scripts we plan to use a Ruby gem called <a href="https://github.com/openSUSE/cheetah">Cheetah</a> and for accessing configuration files we plan to rely on <a href="http://augeas.net/">Augeas</a>.</p>
+<p>Taking some improvements that were needed in YaST2-Bootloader and the drop of perl-bootloader as starting points (or as an excuse, if you prefer), we have used this sprint to develop all the moving parts that will allow us to easily use Cheetah and Augeas within YaST.</p>
+<p>For Cheetah, we have contributed two features to the upstream project: <a href="https://github.com/openSUSE/cheetah/pull/33">chroot support</a> and the ability to provide <a href="https://github.com/openSUSE/cheetah/pull/32">environment variables</a>.</p>
+<p>For Augeas we have developed an object oriented layer called <a href="https://github.com/config-files-api/config_files_api">Config Files Api</a> (shortly CFA). The idea of CFA is to provide specific functionality by mean of plugins. Of course, the <a href="https://github.com/config-files-api/config_files_api_grub2">first plugin</a> we have developed is aimed to manipulation of all the Grub2 configuration files.</p>
+<p>The next step will be to integrate these new components into the next versions of YaST2-Bootloader, hitting your Tumbleweed repositories soon. Of course, after all the usual manual and openQA testing.</p>
+<h3>Libstorage replacement</h3>
+<p>Another low level layer that has been a constant source of headache for YaST developers is libstorage. We use it -specially in the installer and the partitioner- to access disks, partitions, volumes and all that. Once again, the original design have fundamental flaws that limit us in many ways and we have been dreaming for quite some time about writing a replacement for it.</p>
+<p>To make this rewrite fit into the Scrum process, we are using the new redesigned library (find the code <a href="https://github.com/openSUSE/libstorage-bgl-eval">at Github</a> and the packages <a href="https://build.opensuse.org/package/show/home:aschnell:storage-redesign/libstorage">at OBS</a>) to write prototypes for the installer partitioning proposal and for a new partitioning YaST module.</p>
+<p>This new module is only intended as a testbed to showcase the development of the new library and to drive its integration process. It&#8217;s not intended for end users, but after this sprint it can already do some things that are impossible with the current partitioner and even shows some nice graphs really useful for debugging and verifying the behavior of the library.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/01/action-graph.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/action-graph-300x219.png" alt="Libstorage Tech Preview: action graph" width="300" height="219" class="aligncenter size-medium wp-image-11634" /></a></p>
+<p>If you don&#8217;t mind to break your system using unsupported software, you can always fetch <a href="https://github.com/aschnell/yast-storage-ng">the code</a> or <a href="https://build.opensuse.org/package/show/home:aschnell:storage-redesign/yast2-storage-ng">the packages</a>.</p>
+<h3>AutoYaST integration tests</h3>
+<p>Testing is crucial in software development. And integration tests are a must when you are developing an installer. During the last sprints, we have been developing and improving our own solution for testing AutoYaST-driven installations, consisting on a set of tests and a framework to run them.</p>
+<p>The goal for this sprint was to de-couple the tests and the framework. Making it possible to reuse our tests in openQA. As a side effect, we wanted to ease the installation and usage of our testing framework.</p>
+<p>Both goals were achieved, now you can install AutoYaST Integration Tests (not a very original name) following <a href="https://github.com/yast/autoyast-integration-test">the instructions</a> available in the repository and there is already an openQA instance directly running <a href="https://github.com/yast/aytests-tests">the separately available tests</a>.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/01/aytests-help.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/01/aytests-help-300x78.png" alt="aytests-help" width="300" height="78" class="aligncenter size-medium wp-image-11639" /></a></p>
+<h3>Snapper development documentation</h3>
+<p>Last but not least, as a side effect of the development (and the Scrum principles), we have improved the Snapper&#8217;s development documentation. Enjoy it at <a href="https://github.com/openSUSE/snapper">the usual Snapper repository</a>.</p>
+<p>That&#8217;s all folks. Next sprint starts next week and will be three weeks long, so expect more news during the first days of February.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2016/01/07/highlights-of-development-sprint-13/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Live ISO Multi-boot USB revisited &#8211; live-grub-stick</title>
+		<link>https://lizards.opensuse.org/2015/12/25/live-iso-multi-boot-usb-revisited-live-grub-stick/</link>
+		<comments>https://lizards.opensuse.org/2015/12/25/live-iso-multi-boot-usb-revisited-live-grub-stick/#comments</comments>
+		<pubDate>Fri, 25 Dec 2015 09:31:48 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Systems Management]]></category>
+		<category><![CDATA[Usability]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11624</guid>
+		<description><![CDATA[Earlier tool live-fat-stick uses syslinux to create multiboot USB stick/hdd on a vfat parition without having to format the stick preserving existing data and copying whole ISO so the same stick can serve as demo as well as to copy ISOs for distributing. However the disadvantages are all of them that comes from using vfat. [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Earlier tool <a href="https://lizards.opensuse.org/2012/09/13/live-fat-stick/">live-fat-stick</a> uses syslinux to create multiboot USB stick/hdd on a vfat parition without having to format the stick preserving existing data and copying whole ISO so the same stick can serve as demo as well as to copy ISOs for distributing. However the disadvantages are all of them that comes from using vfat.</p>
+<p>Grub2 has come a long way and almost all major distributions now support booting from the iso image via loopback. So here is <a href="https://software.opensuse.org/package/live-grub-stick">live-grub-stick</a> script that uses grub in place of syslinux bringing in all the advantages of using grub2.</p>
+<p>Currently live images of openSUSE, Ubuntu, Fedora and all their clones are supported. Go ahead and <a href="https://github.com/cyberorg/live-fat-stick">fork it</a> if you would like to add support for your distribution.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/12/25/live-iso-multi-boot-usb-revisited-live-grub-stick/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Announcing Li-f-e 42.1</title>
+		<link>https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/</link>
+		<comments>https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/#comments</comments>
+		<pubDate>Mon, 21 Dec 2015 10:37:48 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Architectures]]></category>
+		<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Desktop]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[GNOME]]></category>
+		<category><![CDATA[KDE]]></category>
+		<category><![CDATA[Mono]]></category>
+		<category><![CDATA[Network]]></category>
+		<category><![CDATA[Programming]]></category>
+		<category><![CDATA[Server]]></category>
+		<category><![CDATA[Usability]]></category>
+		<category><![CDATA[Classroom]]></category>
+		<category><![CDATA[Graphic designing]]></category>
+		<category><![CDATA[LTSP]]></category>
+		<category><![CDATA[Multimedia]]></category>
+		<category><![CDATA[openSUSE]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11596</guid>
+		<description><![CDATA[The best Linux distribution for education got a whole lot better, your Li-f-e(Linux for Education) takes a &#8220;Leap&#8221; to 42.1. openSUSE Education community is proud to present this latest edition based on openSUSE 42.1 with all the features, updates and bug fixes available on it till date. This effectively makes it the only enterprise grade [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>The best Linux distribution for education got a whole lot better, your <a href="https://en.opensuse.org/openSUSE:Education-Li-f-e">Li-f-e(Linux for Education)</a> takes a &#8220;<a href="https://news.opensuse.org/2015/11/04/opensuse-leap-42-1-becomes-first-hybrid-distribution/">Leap</a>&#8221; to 42.1. <a href="https://en.opensuse.org/Education">openSUSE Education</a> community is proud to present this latest edition based on <a href="https://en.opensuse.org/Portal:42.1">openSUSE 42.1</a> with all the features, updates and bug fixes available on it till date. This effectively makes it the only enterprise grade long term supported(LTS) distribution for Education.</p>
+<p>As with previous releases <a href="http://download.opensuse-education.org/~cyberorg/opensuse-edu-life-4211-packages.txt">we have bundled a ton of softwares</a> on this <a href="https://en.opensuse.org/Live_USB_stick">live DVD/USB</a> specially packaged for education, along with the Plasma, GNOME and Mate Desktop Environments, full multimedia experience is also provided out of the box thanks to the Packman repositories. Only x86_64 architecture is supported, if you have a lot of machines that only support x86 then read on to find out how you can extend their Li-f-e.<br />
+<span id="more-11596"></span></p>
+<p>You can of course very <a href="http://cyberorg.github.io/kiwi-ltsp-howto/">easily turn Li-f-e to full-fledged LTSP server</a> to PXE boot machines in your local network. Booting both i686 and x86_64 architectures is supported. In case you need to PXE boot machines below i686 then you would have to <a href="https://software.opensuse.org/package/kiwi-ltsp-tinycore-tc">install this package</a>.</p>
+<p>Happy holidays!</p>
+
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot7/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot7-150x150.png" class="attachment-thumbnail" alt="Games" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot8/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot8-150x150.png" class="attachment-thumbnail" alt="Development" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot10/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot10-150x150.png" class="attachment-thumbnail" alt="Graphics" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot16/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot16-150x150.png" class="attachment-thumbnail" alt="Learning" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot15/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot15-150x150.png" class="attachment-thumbnail" alt="Learning" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot12/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot12-150x150.png" class="attachment-thumbnail" alt="Multimedia" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/snapshot11/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/snapshot11-150x150.png" class="attachment-thumbnail" alt="Office" /></a>
+<a href='https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/screenshot-from-2015-12-20-16-41-37/'><img width="150" height="150" src="https://lizards.opensuse.org/wp-content/uploads/2015/12/Screenshot-from-2015-12-20-16-41-37-150x150.png" class="attachment-thumbnail" alt="Mate desktop" /></a>
+
+<p>Get Li-f-e from here: <a href="http://sourceforge.net/projects/opensuse-edu/files/download/ISOs/openSUSE-Edu-li-f-e.x86_64-42.1.1.iso/download">Direct Download</a> | <a href="http://sourceforge.net/projects/opensuse-edu/files/download/ISOs/openSUSE-Edu-li-f-e.x86_64-42.1.1.iso.md5/download">md5sum</a> | <a href="http://download.opensuse-education.org/ISOs/">Alternate download and mirrors</a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/12/21/announcing-li-f-e-42-1/feed/</wfw:commentRss>
+		<slash:comments>5</slash:comments>
+		</item>
+		<item>
+		<title>Let&#8217;s blog about YaST</title>
+		<link>https://lizards.opensuse.org/2015/12/15/lets-blog-about-yast/</link>
+		<comments>https://lizards.opensuse.org/2015/12/15/lets-blog-about-yast/#comments</comments>
+		<pubDate>Tue, 15 Dec 2015 12:56:51 +0000</pubDate>
+		<dc:creator><![CDATA[Yast Team]]></dc:creator>
+				<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[YaST]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[openSUSE]]></category>
+		<category><![CDATA[Tumbleweed]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11584</guid>
+		<description><![CDATA[Since some months ago, the YaST Team at SUSE has been using Scrum to organize the work. Among other things, that means the whole team takes part in a review meeting every three weeks to showcase the fixed bugs and the implemented features. To support those review meetings we often create screenshots, text summaries, short [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Since some months ago, the YaST Team at SUSE has been using <a href="https://en.wikipedia.org/wiki/Scrum_(software_development)">Scrum</a> to organize the work. Among other things, that means the whole team takes part in a review meeting every three weeks to showcase the fixed bugs and the implemented features. To support those review meetings we often create screenshots, text summaries, short videos and other material. Is it not a pity that all that content get unnoticed for curious users and potential contributors?</p>
+<p>In order to give the SUSE and openSUSE communities an opportunity to lurk into those review meetings, we have decided to create this team blog and post here the highlights after every meeting. Not all the fixes and features will be covered, but we&#8217;ll try to blog about the most exciting or relevant changes.</p>
+<p>Obviously, many of those posts will be more exciting for developers and Tumbleweed users than for users of the stable release (bugfixes tend to be unexciting). But, as some kind of bonus track, Leap 42.1 users can always revisit the <a href="https://en.opensuse.org/Features#openSUSE_technologies">summary of what the recent release brought</a> to the YaST (and friends) world.</p>
+<p>The current sprint ends right before Christmas, so stay tuned!</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/12/15/lets-blog-about-yast/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Proprietary AMD/ATI Catalyst fglrx rpms new release 15.11 (15.300.1025-1)</title>
+		<link>https://lizards.opensuse.org/2015/12/06/proprietary-amdati-catalyst-fglrx-rpms-new-release-15-11-15-300-1025-1/</link>
+		<comments>https://lizards.opensuse.org/2015/12/06/proprietary-amdati-catalyst-fglrx-rpms-new-release-15-11-15-300-1025-1/#comments</comments>
+		<pubDate>Sun, 06 Dec 2015 19:37:24 +0000</pubDate>
+		<dc:creator><![CDATA[Bruno Friedmann]]></dc:creator>
+				<category><![CDATA[Base System]]></category>
+		<category><![CDATA[Desktop]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[GNOME]]></category>
+		<category><![CDATA[KDE]]></category>
+		<category><![CDATA[Packaging]]></category>
+		<category><![CDATA[X.org]]></category>
+		<category><![CDATA[XFCE]]></category>
+		<category><![CDATA[13.1]]></category>
+		<category><![CDATA[13.2]]></category>
+		<category><![CDATA[42.1]]></category>
+		<category><![CDATA[amd]]></category>
+		<category><![CDATA[ATI]]></category>
+		<category><![CDATA[fglrx]]></category>
+		<category><![CDATA[Kernel]]></category>
+		<category><![CDATA[Tumbleweed]]></category>
+		<category><![CDATA[unified]]></category>
+		<category><![CDATA[xorg]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11582</guid>
+		<description><![CDATA[Time to get an update for fglrx: the new release has been build for 13.1, 13.2, Leap 42.1, and tumbleweed 20151201 Tumbleweed beware : broken Xorg It seems since the release, that a number of report of broken xorg with gdm, ssdm and so&#8230; segfaulting You can still use the previous version hanging on the [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Time to get an update for fglrx: the new release has been build for 13.1, 13.2, Leap 42.1, and tumbleweed 20151201</p>
+<h1 style="color:red">Tumbleweed beware : broken Xorg</h1>
+<p>It seems since the release, that a number of report of broken xorg with gdm, ssdm and so&#8230; segfaulting</p>
+<p>You can still use the previous version hanging on the server. But I doubt it would work better</p>
+<p>As soon, with Sebastian Siebert we have a patch for, I will republish a new build</p>
+<p>Informations &amp; bugreport <a href="https://www.sebastian-siebert.de/2015/12/05/opensuse-proprietaeren-grafik-treiber-amd-catalyst-15-11-als-rpm-installieren">Sebastian&#8217;s blog</a> or <a href="https://lizards.opensuse.org/2015/12/05/amd-catalyst-15-11-for-opensuse-new-makerpm-amd-script-is-available/">lizards.o.o</a><br />
+<br />
+The proposed drivers support kernel up to version 4.4
+</p>
+<p>AMD release note <a href="http://support.amd.com/en-us/kb-articles/Pages/AMDRadeonSoftwareCrimsonEdition15-11LINReleaseNotes.aspx">available</p>
+<h4>Sebastien Siebert making script</h4>
+<p style="clear:both"><a href="http://www.sebastian-siebert.de/">Sebastian Siebert posts about fglrx</a></p>
+<p>If you have any problems with the driver, don&#8217;t be afraid to report to Sebastian (German and English bugreports are gladly accepted).<br />
+he will try, as far as I am able to reproduce the bug. Together with the necessary system information, he will go directly to the right place at AMD to have the bug fixed in the next driver release.<br />
+Thank you very much, Sebastian.
+</p>
+<p>See below what to do in case of troubles.</p>
+<p>Or you can also ping him on irc (freespacer)</p>
+<h4>Debugging troubles</h4>
+<p>I recommend in case of trouble the use of <a href="http://www.sebastian-siebert.de/downloads/makerpm-amd-15.11.sh">his script</a> which can collect the whole informations needed to help you. then you just have to issue a simple commande in console to collect all informations, you can review them, and finally transmit them.<br />
+Check the website to get the latest.
+</p>
+<pre>su -c 'sh makerpm-amd-15.11.sh -ur'
+The system report 'amd-report.txt' was generated.                                                                                                          [ OK ]
+Do you want to read the system report 'amd-report.txt' now? yes/no [y/n]: y
+Are you sure to upload the above-named system report to sprunge.us? yes/no [y/n]: y
+
+The report was uploaded to sprunge.us.
+   The link is:  <a href="http://sprunge.us/eMEB">http://sprunge.us/eMEB</a>
+</pre>
+<p>Copy paste the link in the comment zone of Sebastian post</p>
+<p>All proudly distributed by openSUSE powered server and sponsored by <a href="http://www.ioda-net.ch">Ioda-Net Sàrl</a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/12/06/proprietary-amdati-catalyst-fglrx-rpms-new-release-15-11-15-300-1025-1/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>AMD Catalyst 15.11 for openSUSE – new makerpm-amd-script is available</title>
+		<link>https://lizards.opensuse.org/2015/12/05/amd-catalyst-15-11-for-opensuse-new-makerpm-amd-script-is-available/</link>
+		<comments>https://lizards.opensuse.org/2015/12/05/amd-catalyst-15-11-for-opensuse-new-makerpm-amd-script-is-available/#comments</comments>
+		<pubDate>Sat, 05 Dec 2015 23:00:55 +0000</pubDate>
+		<dc:creator><![CDATA[Sebastian Siebert]]></dc:creator>
+				<category><![CDATA[Base System]]></category>
+		<category><![CDATA[Desktop]]></category>
+		<category><![CDATA[GNOME]]></category>
+		<category><![CDATA[KDE]]></category>
+		<category><![CDATA[Kernel]]></category>
+		<category><![CDATA[Packaging]]></category>
+		<category><![CDATA[X.org]]></category>
+		<category><![CDATA[11.4]]></category>
+		<category><![CDATA[12.1]]></category>
+		<category><![CDATA[12.2]]></category>
+		<category><![CDATA[12.3]]></category>
+		<category><![CDATA[13.1]]></category>
+		<category><![CDATA[13.2]]></category>
+		<category><![CDATA[42.1]]></category>
+		<category><![CDATA[amd]]></category>
+		<category><![CDATA[ATI]]></category>
+		<category><![CDATA[driver]]></category>
+		<category><![CDATA[fglrx]]></category>
+		<category><![CDATA[Linux]]></category>
+		<category><![CDATA[openSUSE]]></category>
+		<category><![CDATA[radeon]]></category>
+		<category><![CDATA[rpm]]></category>
+		<category><![CDATA[Tumbleweed]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11579</guid>
+		<description><![CDATA[AMD has released the new AMD Catalyst 15.11 (Radeon Crimson Edition). My script replaces the existing packaging script with an updated packaging script. It supports up to Kernel 4.4. (Official support up to Kernel 3.19) I have adapted the AMD driver to the Kernel 4.4 (rc3). For the moment it works for Kernel 4.4-rc3. Unfortunately [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>AMD has released the new AMD Catalyst 15.11 (Radeon Crimson Edition). My script replaces the existing packaging script with an updated packaging script. It supports up to Kernel 4.4. (Official support up to Kernel 3.19)</p>
+<p>I have adapted the AMD driver to the Kernel 4.4 (rc3). For the moment it works for Kernel 4.4-rc3. Unfortunately the AMD driver has a compatibility issue in combination with the GNOME Desktopmanager and X-Server. As a workaround, I recommend for GNOME another Desktopmanager such as lightdm until the issue is hopefully fixed.</p>
+<p>Resolved Issues:</p>
+<ul>
+<li>[SWDEV-55204] Stuttering when running glxgears with VSync enabled</li>
+<li>[SWDEV-7339] Intermittent mouse cursor corruption</li>
+</ul>
+<p>Link: <a href="http://support.amd.com/en-us/kb-articles/Pages/AMDRadeonSoftwareCrimsonEdition15-11LINReleaseNotes.aspx">AMD Catalyst 15.11 Release Notes</a></p>
+<p>Downloads:</p>
+<ul>
+<li>Script: <a href="https://www.sebastian-siebert.de/downloads/makerpm-amd-15.11.sh" target="_blank">makerpm-amd-15.11.sh</a></li>
+<li>SHA1: <a href="https://www.sebastian-siebert.de/downloads/makerpm-amd-15.11.sh.sha1" target="_blank">makerpm-amd-15.11.sh.sha1</a></li>
+</ul>
+<p>Installation guide (English):<br />
+<a href="http://en.opensuse.org/SDB:AMD_fglrx#Building_the_rpm_yourself">http://en.opensuse.org/SDB:AMD_fglrx#Building_the_rpm_yourself</a></p>
+<p>Bruno Friedmann will build the new RPM packages in the fglrx repository. Stay tune!</p>
+<p>If you find any issue with the driver. Don’t hesitate to contact me. I am in contact with AMD and can forward your issue to the right place. Feedback are welcome.</p>
+<p>A report of your system is very helpful beside your feedback. You can generate it with the script:<br />
+<code>su -c 'sh makerpm-amd-15.11.sh -ur'</code></p>
+<p>Have a lot of fun!</p>
+<p>Sebastian<br />
+openSUSE member / Official AMD Packaging Script Maintainer for openSUSE<br />
+German Blog: <a href="https://www.sebastian-siebert.de/2015/12/05/opensuse-proprietaeren-grafik-treiber-amd-catalyst-15-11-als-rpm-installieren/">openSUSE – proprietären Grafik-Treiber AMD Catalyst 15.11 als RPM installieren</a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/12/05/amd-catalyst-15-11-for-opensuse-new-makerpm-amd-script-is-available/feed/</wfw:commentRss>
+		<slash:comments>3</slash:comments>
+		</item>
+		<item>
+		<title>Banana Pi M2 running openSUSE Tumbleweed</title>
+		<link>https://lizards.opensuse.org/2015/12/03/banana-pi-m2-running-opensuse-tumbleweed/</link>
+		<comments>https://lizards.opensuse.org/2015/12/03/banana-pi-m2-running-opensuse-tumbleweed/#comments</comments>
+		<pubDate>Thu, 03 Dec 2015 05:33:19 +0000</pubDate>
+		<dc:creator><![CDATA[Jigish Gohil]]></dc:creator>
+				<category><![CDATA[Architectures]]></category>
+		<category><![CDATA[Base System]]></category>
+		<category><![CDATA[Derivative]]></category>
+		<category><![CDATA[Distribution]]></category>
+		<category><![CDATA[Factory]]></category>
+		<category><![CDATA[XFCE]]></category>
+		<category><![CDATA[ARM]]></category>
+		<category><![CDATA[arm7]]></category>
+		<category><![CDATA[Banana Pi M2]]></category>
+		<category><![CDATA[Xfce]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11575</guid>
+		<description><![CDATA[Following up from my earlier post about openSUSE LTSP on Banana Pi, Nora Lee from the manufacturer of the board got in touch with me and sent me a couple of their new boards- Banana Pi M2, runs on A31s quad-core CPU and has 1G RAM, powerful enough to run openSUSE Tumbleweed with Xfce Desktop. [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>Following up from my earlier post about <a href="https://lizards.opensuse.org/2014/12/16/ltsp-client-goes-banana-pi/">openSUSE LTSP on Banana Pi</a>, <a href="https://plus.google.com/102091635847832058268">Nora Lee</a> from the manufacturer of the board got in touch with me and sent me a couple of their new boards- <a href="http://www.bananapi.com/index.php/component/content/article?layout=edit&amp;id=73">Banana Pi M2,</a> runs on A31s quad-core CPU and has 1G RAM, powerful enough to run openSUSE Tumbleweed with Xfce Desktop.</p>
+<p>Here is how you can get openSUSE running on Banana Pi M2.</p>
+<p>* <a href="http://sourceforge.net/projects/cyberorg-home/files/opensuse-arm/openSUSE-Tumbleweed-Bpi-M2-Xfce.tar.xz/download">Download the image</a></p>
+<p>* Extract the archive to get openSUSE-Tumbleweed-Bpi-M2-Xfce.img</p>
+<p>* Dump openSUSE-Tumbleweed-Bpi-M2-Xfce.img on to a SD card<br />
+(dd if=/path/to/openSUSE-Tumbleweed-Bpi-M2-Xfce.img of=/dev/sdX bs=4M; sync #replace /dev/sdX with your actual SD card device)</p>
+<p>*  In case you have a bigger SD card, use yast2 disk(partitioner) to &#8220;expand&#8221; the second partition. You can use yast’s package manager to install more software. The default password for root is <strong>linux</strong>, you may want to change that first thing after booting.</p>
+<p>I am unable to get sound on this hardware, probably <a href="https://github.com/BPI-SINOVOIP/BPI-Mainline-bsp">their kernel</a> is missing sound related modules, if you figure out how to get sound working drop me a line so I can include it in next release.Everything else(wifi, hdmi out, USB ports etc) works well enough.</p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/12/03/banana-pi-m2-running-opensuse-tumbleweed/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>Hi how are you doing? Sorry you can&#8217;t get through. Just leave your name and you number and I&#8217;ll get back to you</title>
+		<link>https://lizards.opensuse.org/2015/11/27/hi-how-are-you-doing-sorry-you-cant-get-through-just-leave-your-name-and-you-number-and-ill-get-back-to-you/</link>
+		<comments>https://lizards.opensuse.org/2015/11/27/hi-how-are-you-doing-sorry-you-cant-get-through-just-leave-your-name-and-you-number-and-ill-get-back-to-you/#comments</comments>
+		<pubDate>Fri, 27 Nov 2015 06:55:23 +0000</pubDate>
+		<dc:creator><![CDATA[Tuukka Pasanen]]></dc:creator>
+				<category><![CDATA[lizards.openSUSE.org]]></category>
+		<category><![CDATA[Blender]]></category>
+		<category><![CDATA[FreeCAD]]></category>
+		<category><![CDATA[Fritzing]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11569</guid>
+		<description><![CDATA[No.. I haven&#8217;t forget you! I think of you every day, night and if I&#8217;m honest all the time. You and you and you and especially you who are reading these lines. This is going to be sort blog entry. I want you to know what you should start doing! Yes just stop being social [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p>No.. I haven&#8217;t forget you! I think of you every day, night and if I&#8217;m honest all the time. You and you and you and especially you who are reading these lines. This is going to be sort blog entry. I want you to know what you should start doing! Yes just stop being social in internet. Get out of your comfort zone and start <del>spank the monkey</del> (oh.. sorry not spank the monkey this is children approved blog..) er.. learning new stuff.<span id="more-11569"></span></p>
+<p>Start you maker project and learn how to 3D with <a href="http://www.blender.org/">Blender</a> (it&#8217;s marvelous 3D application). After Blender there is no excuse and it&#8217;s free (but remember if you really like it give something back). Are you on more on CAD? Learn 3D CAD with <a href="http://freecadweb.org/">FreeCAD</a> (Again amazing tool). Want to ride IoT wave but you don&#8217;t have too much money then get new shiny <a href="http://linuxgizmos.com/tiny-5-dollar-raspberry-pi-zero-keeps-it-simple/">Tiny $5 Raspberry Pi Zero</a> or <a href="http://nextthing.co/">9$ C.H.I.P</a> and make your <a href="http://fritzing.org">Fritzing</a> electric boogie with ease (and by the way you can commit those boards to library. It&#8217;s open source!). You are in music how about doing some DJ:n with linux? <a href="http://mixxx.org/">Mixxx</a> just got shiny 2.0 RC1 out. Are you more reading type and need something to manage you e-books: <a href="http://calibre-ebook.com/">Calibre</a> is here to help. Huh so much to do so less time!</p>
+<p>Where to get them? openSUSE have RPM for all of them just learn to search them from Packman or from <a href="https://build.opensuse.org">OBS</a>. Sorry to say Raspberry Pi <em>Zero is currently not supported but you can help to add it</em> to ARM boards working with openSUSE same problems with C.H.I.P (If you have Raspberry Pi 1/2 just get image for them from openSUSE ARM image and start hacking). You should learn how to add new repos to YaST2 and add <a href="http://packman.links2linux.de/">Packman</a> repo for new FreeCAD, Fritzing and Mixxx. Yes! most of them run also on Windows and Mac OS X. Now smile on, thumbs up and <strong>get your groove on</strong> with title song: <a href="https://www.youtube.com/watch?v=pxEu4uf0-b8">De La Soul &#8211; Ring Ring Ring (Ha Ha Hey)</a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/11/27/hi-how-are-you-doing-sorry-you-cant-get-through-just-leave-your-name-and-you-number-and-ill-get-back-to-you/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+		<item>
+		<title>What happened @ FOSSCOMM 2015, Athens Nov 6-8</title>
+		<link>https://lizards.opensuse.org/2015/11/12/fosscomm-2015-athens-nov-6-8/</link>
+		<comments>https://lizards.opensuse.org/2015/11/12/fosscomm-2015-athens-nov-6-8/#comments</comments>
+		<pubDate>Thu, 12 Nov 2015 13:21:58 +0000</pubDate>
+		<dc:creator><![CDATA[Efstathios Iosifidis]]></dc:creator>
+				<category><![CDATA[Ambassadors]]></category>
+		<category><![CDATA[Events]]></category>
+		<category><![CDATA[Marketing]]></category>
+		<category><![CDATA[Athens]]></category>
+		<category><![CDATA[conference]]></category>
+		<category><![CDATA[Enlightenment]]></category>
+		<category><![CDATA[FOSSCOMM]]></category>
+		<category><![CDATA[Greek community]]></category>
+		<category><![CDATA[Leap]]></category>
+		<category><![CDATA[openqa]]></category>
+		<category><![CDATA[report]]></category>
+		<category><![CDATA[Tumbleweed]]></category>
+
+		<guid isPermaLink="false">http://lizards.opensuse.org/?p=11564</guid>
+		<description><![CDATA[The 8th Free and Open Source Software Communities Meeting (FOSSCOMM) took place in Athens (Greece), November 6-8th 2015 at the Technical Educational Institute of Athens. The Conference started early on Saturday morning welcoming the participants and with the key note. Various presentations about open source software, hardware constructions and some workshops took place. Presentations such [&#8230;]]]></description>
+				<content:encoded><![CDATA[<p><a title="DSC_0746" href="https://www.flickr.com/photos/eiosifidis/22937556695/in/album-72157660299594107/"><img class=" aligncenter" src="https://farm1.staticflickr.com/584/22937556695_aa0f2f7d66_n.jpg" alt="DSC_0746" width="320" height="213" /></a></p>
+<p>The 8th Free and Open Source Software Communities Meeting (<a href="http://fosscomm.teiath.gr/" target="_blank">FOSSCOMM</a>) took place in Athens (Greece), November 6-8th 2015 at the <a href="http://www.teiath.gr/articles.php?id=98&amp;lang=el" target="_blank">Technical Educational Institute of Athens</a>.</p>
+<p>The Conference started early on Saturday morning welcoming the participants and with the key note. Various presentations about open source software, hardware constructions and some workshops took place. Presentations such as Raspberry Pi arcade, openstack, OSGeo, ownCloud, Bitcoin and many more were quite interested by the visitors.</p>
+<p><a title="DSC_0716" href="https://www.flickr.com/photos/eiosifidis/22316436533/in/album-72157660299594107/"><img class=" aligncenter" src="https://farm1.staticflickr.com/670/22316436533_ee99406122_n.jpg" alt="DSC_0716" width="320" height="213" /></a></p>
+<p>Greek openSUSE community was there with a booth and some presentations. On Saturday Alex P. Natsios presented “Enlightment on openSUSE”, an alternative GUI, and the other presentation was about “openQA”. Since openSUSE Leap 42.1 was very fresh, Alexandros Vennos took the opportunity to present what are openSUSE Leap 42.1 and Tumbleweed, the differences and what to install on what occasions. Presentation had title “openSUSE – Leaping Ahead”.</p>
+<p><a title="DSC_0709" href="https://www.flickr.com/photos/eiosifidis/22911595656/in/album-72157660299594107/"><img class=" aligncenter" src="https://farm6.staticflickr.com/5644/22911595656_3e32100290_n.jpg" alt="DSC_0709" width="320" height="213" /></a></p>
+<p>The booth was quite crowded. We had some left over DVDs of 13.2 but we proposed the visitors to install Leap 42.1. The question we were asked most was what is the difference between openSUSE Leap and Tubleweed and why to install and on what ocasion. We even created couple of bootable USBs from the ISOs of Leap. We had a Banana Pi running Tumbleweed with MATE playing a video loop of openSUSE Leap 42.1 KDE review. We gave almost all of our promo materials to the visitors since they were interested on openSUSE.</p>
+<p>For more pictures check <a href="https://www.flickr.com/groups/fosscomm2015/" target="_blank">Flickr</a></p>
+<p><a title="DSC_0736" href="https://www.flickr.com/photos/eiosifidis/22314845674/in/album-72157660299594107/"><img class=" aligncenter" src="https://farm1.staticflickr.com/640/22314845674_3595973cbf_n.jpg" alt="DSC_0736" width="320" height="213" /></a></p>
+]]></content:encoded>
+			<wfw:commentRss>https://lizards.opensuse.org/2015/11/12/fosscomm-2015-athens-nov-6-8/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		</item>
+	</channel>
+</rss>

--- a/jekyll/lizards_html.rb
+++ b/jekyll/lizards_html.rb
@@ -1,0 +1,171 @@
+# parsing HTML
+require "nokogiri"
+# URL parsing
+require "uri"
+# HTTP download
+require "net/http"
+# HTML -> Markdown conversion
+require "kramdown"
+# parse date
+require "date"
+
+class LizardsHtmlImporter
+  attr_reader :html_file
+
+  def initialize(html_file)
+    @html_file = html_file
+  end
+
+  # import only some posts, the rest is imported via the RSS feed
+  POSTS_TO_IMPORT = [
+    "Highlights of YaST development sprint 21",
+    "Highlights of YaST development sprint 22",
+    "Highlights of YaST development sprint 23"
+  ]
+
+  # Process the import.
+  def process
+    tree = Nokogiri::HTML(File.read(html_file))
+
+    FileUtils.mkdir_p("_posts")
+
+    # find all posts
+    tree.xpath("//div[contains(@class,\"post\")]").each do |post|
+      # import only the listed posts
+      import_post(post) if POSTS_TO_IMPORT.include?(post_title(post))
+    end
+  end
+
+  def import_post(post)
+    puts "Importing post \"#{post_title(post)}\"..."
+    content = post.xpath("div[@class=\"entry\"]").first
+    formatted_date = post_date(post).strftime('%Y-%m-%d')
+
+    # download images from lizards.opensuse.org and replace the URLs
+    download_and_replace_images(content, "images/#{formatted_date}")
+
+    html = content.children.to_html
+
+    # convert MSDOS newlines to Unix newlines
+    html.gsub!(/\r\n?/, "\n")
+
+    # emoji conversion
+    replace_emoji(html)
+
+    # convert to Markdown
+    md_content = Kramdown::Document.new(html, :html_to_native => true).to_kramdown
+
+    file_path = "_posts/#{formatted_date}-#{post_file_name(post)}.md"
+    # add the YAML header
+    File.write(file_path, yaml_header(post) + "---\n\n" + md_content)
+  end
+
+  # simple&stupid emoji replacement, we used just few emoticons
+  # do not overengeneer
+  EMOJI = {
+    '<img src="https://s.w.org/images/core/emoji/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" />' => ":wink:",
+    '<img src="https://s.w.org/images/core/emoji/2/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" />' => ":wink:",
+    '<img src="https://s.w.org/images/core/emoji/72x72/1f642.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" />' => ":simple_smile:",
+    '<img src="https://s.w.org/images/core/emoji/2/72x72/1f642.png" alt="&#x1f642;" class="wp-smiley" style="height: 1em; max-height: 1em;" />' => ":simple_smile:"
+  }
+
+  def replace_emoji(post)
+    EMOJI.each do |link, emoji|
+      post.gsub!(link, emoji)
+    end
+  end
+
+  def download_and_replace_images(post, download_dir)
+    # replace images
+    download_and_replace_tag(post, download_dir, "img", "src")
+    # replace links to images
+    download_and_replace_tag(post, download_dir, "a", "href")
+  end
+
+  # replace images by a local copy, download images if not already present
+  def download_and_replace_tag(tree, download_dir, tag, attribute)
+    # replace only URLs pointing to an uploaded content
+    tree.xpath(".//#{tag}[contains(@#{attribute},\"//lizards.opensuse.org/wp-content/uploads\")]").each do |node|
+      src = node.attribute(attribute).value
+      # add HTTPS if there is no protocol
+      src = "https:#{src}" if src.start_with?("//")
+      url = URI(src)
+
+      if url.scheme == "http" || url.scheme == "https"
+        file = File.join(download_dir, File.basename(url.path))
+        if !File.exist?(file)
+          FileUtils.mkdir_p(download_dir)
+          download(url, file)
+        end
+        # use relative path so it does not depend on the root location
+        node.attribute(attribute).value = "../../../../#{file}"
+      else
+        $stderr.puts "Unknown protocol in URL: #{src}"
+      end
+
+      attributes_cleanup(node)
+    end
+  end
+
+  def download(url, file)
+    puts "Downloading #{url}..."
+    content = Net::HTTP.get(url)
+
+    puts "Saving to #{file}"
+    File.write(file, content)
+  end
+
+  def yaml_header(item)
+    header = {
+      # Note: 'description' is not present in HTML
+      'layout' => 'post',
+      'date' => post_date(item),
+      'title' => post_title(item),
+      # Note: the categories and tags must be fixed manually
+      # both are mixed into a single list
+      'category' => post_tags(item),
+      'tags' => post_tags(item)
+    }
+
+    header.to_yaml
+  end
+
+  # post file name
+  def post_file_name(post)
+    name = post_title(post).split(%r{ |!|’|/|:|&|-|$|,|\(|\)}).map do |i|
+      i.downcase if i != ''
+    end
+
+    name.compact.join('-')
+  end
+
+  # get the date from the post permalink
+  def post_date(post)
+    post_link = post.xpath("h2/a").first.attribute("href").to_s
+
+    if post_link =~ /lizards\.opensuse\.org\/([0-9]{4}\/[0-9]{2}\/[0-9]{2})\//
+      return Date.parse(Regexp.last_match[1])
+    end
+
+    nil
+  end
+
+  # get the post tags ans categories
+  def post_tags(post)
+    post.xpath("p[@class=\"postmetadata\"]/a[@rel=\"category tag\"]").map(&:text)
+  end
+
+  # get the post title
+  def post_title(post)
+    post.xpath("h2/a").first.text
+  end
+
+  # delete unused attributes
+  def attributes_cleanup(node)
+    node.delete("width")
+    node.delete("height")
+    node.delete("class")
+    node.delete("srcset")
+    node.delete("sizes")
+  end
+end

--- a/jekyll/lizards_importer.rb
+++ b/jekyll/lizards_importer.rb
@@ -1,0 +1,14 @@
+#! /usr/bin/env ruby
+
+require "jekyll-import"
+require_relative "lizards_rss"
+require_relative "lizards_html"
+
+Dir["*.xml"].each do |xml|
+  JekyllImport::Importers::LizardsRSS.run( "source" => xml )
+end
+
+Dir["*.html"].each do |html|
+  importer = LizardsHtmlImporter.new(html)
+  importer.process
+end

--- a/jekyll/lizards_rss.rb
+++ b/jekyll/lizards_rss.rb
@@ -1,0 +1,167 @@
+# parsing HTML
+require "nokogiri"
+# URL parsing
+require "uri"
+# HTTP download
+require "net/http"
+# HTML -> Markdown conversion
+require "kramdown"
+
+# The code is based on the JekyllImport::Importers::RSS code
+module JekyllImport
+  module Importers
+    class LizardsRSS < Importer
+      def self.specify_options(c)
+        c.option 'source', '--source NAME', 'The RSS file or URL to import'
+      end
+
+      def self.validate(options)
+        if options['source'].nil?
+          abort "Missing mandatory option --source."
+        end
+      end
+
+      def self.require_deps
+        JekyllImport.require_with_fallback(%w[
+          rss
+          rss/1.0
+          rss/2.0
+          open-uri
+          fileutils
+          safe_yaml
+        ])
+      end
+
+      # Process the import.
+      #
+      # source - a URL or a local file String.
+      #
+      # Returns nothing.
+      def self.process(options)
+        source = options.fetch('source')
+
+        content = File.read(source)
+        rss = ::RSS::Parser.parse(content, false)
+
+        raise "There doesn't appear to be any RSS items at the source (#{source}) provided." unless rss
+        FileUtils.mkdir_p("_posts")
+
+        rss.items.each do |item|
+          # convert only the YaST team posts
+          import_post(item) if item.dc_creator == "Yast Team"
+        end
+      end
+
+      def self.import_post(item)
+        puts "Importing post \"#{item.title}\"..."
+        formatted_date = item.date.strftime('%Y-%m-%d')
+        post = item.content_encoded
+
+        # convert MSDOS newlines to Unix newlines
+        post.gsub!(/\r\n?/, "\n")
+        # emoji conversion
+        replace_emoji(post)
+        # download images from lizards.opensuse.org and replace the URLs
+        download_and_replace_images(post, "images/#{formatted_date}")
+        # convert to Markdown
+        md_content = Kramdown::Document.new(post, :html_to_native => true).to_kramdown
+
+        file_path = "_posts/#{formatted_date}-#{post_name(item)}.md"
+        # add the YAML header
+        File.write(file_path, yaml_header(item) + "---\n\n" + md_content)
+      end
+
+      # simple&stupid emoji replacement, we used just few emoticons
+      # do not overengeneer
+      EMOJI = {
+        '<img src="https://s.w.org/images/core/emoji/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" />' => ":wink:",
+        '<img src="https://s.w.org/images/core/emoji/2/72x72/1f609.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" />' => ":wink:",
+        '<img src="https://s.w.org/images/core/emoji/72x72/1f642.png" alt="&#x1f609;" class="wp-smiley" style="height: 1em; max-height: 1em;" />' => ":simple_smile:",
+        '<img src="https://s.w.org/images/core/emoji/2/72x72/1f642.png" alt="&#x1f642;" class="wp-smiley" style="height: 1em; max-height: 1em;" />' => ":simple_smile:"
+      }
+
+      def self.replace_emoji(post)
+        EMOJI.each do |link, emoji|
+          post.gsub!(link, emoji)
+        end
+      end
+
+      def self.download_and_replace_images(post, download_dir)
+        tree = Nokogiri::HTML(post)
+
+        # replace images
+        download_and_replace_tag(tree, download_dir, "img", "src")
+        # replace links to images
+        download_and_replace_tag(tree, download_dir, "a", "href")
+
+        # build the HTML back from the modified tree, remove the body wrapper
+        # added by Nokogiri
+        post.replace(tree.xpath("//body").children.to_html)
+      end
+
+      def self.download_and_replace_tag(tree, download_dir, tag, attribute)
+        # replace only URLs pointing to an uploaded content
+        tree.xpath("//#{tag}[contains(@#{attribute},\"//lizards.opensuse.org/wp-content/uploads\")]").each do |node|
+          src = node.attribute(attribute).value
+          # add HTTPS if there is no protocol
+          src = "https:#{src}" if src.start_with?("//")
+          url = URI(src)
+
+          if url.scheme == "http" || url.scheme == "https"
+            file = File.join(download_dir, File.basename(url.path))
+            if !File.exist?(file)
+              FileUtils.mkdir_p(download_dir)
+              download(url, file)
+            end
+            # use relative path so it does not depend on the root location
+            node.attribute(attribute).value = "../../../../#{file}"
+          else
+            $stderr.puts "Unknown protocol in URL: #{src}"
+          end
+
+          attributes_cleanup(node)
+        end
+      end
+
+      def self.download(url, file)
+        puts "Downloading #{url}..."
+        content = Net::HTTP.get(url)
+
+        puts "Saving to #{file}"
+        File.write(file, content)
+      end
+
+      def self.yaml_header(item)
+        header = {
+          'layout' => 'post',
+          'date' => item.pubDate,
+          'title' => item.title,
+          'description' => item.description,
+          # the catogires and tags must be fixed manually
+          # RSS feed mixes both into a single list
+          'category' => item.categories.map(&:content),
+          'tags' => item.categories.map(&:content),
+        }
+
+        header.to_yaml
+      end
+
+      def self.post_name(item)
+        name = item.title.split(%r{ |!|’|/|:|&|-|$|,|\(|\)}).map do |i|
+          i.downcase if i != ''
+        end
+
+        name.compact.join('-')
+      end
+
+      # delete unused attributes
+      def self.attributes_cleanup(node)
+        node.delete("width")
+        node.delete("height")
+        node.delete("class")
+        node.delete("srcset")
+        node.delete("sizes")
+      end
+    end
+  end
+end

--- a/jekyll/page2.html
+++ b/jekyll/page2.html
@@ -1,0 +1,995 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" itemscope itemtype="http://schema.org/Blog">
+<head>
+
+
+  <!-- include local CSS file -->
+  <link rel="stylesheet" href="https://lizards.opensuse.org/wp-content/themes/bento/style.css" type="text/css" media="screen" />
+  <link rel="stylesheet" href="//static.opensuse.org/themes/bento/css/print.css" type="text/css" media="print" />
+
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+  <!-- opengraph metadata -->
+  <meta property="og:site_name" content="openSUSE Lizards" />
+  <meta itemprop="name" content="openSUSE News Blog">
+  <meta itemprop="description" content="openSUSE News Blog">
+
+  <meta property="og:type" content="blog" />
+  <meta property="og:title" content="openSUSE Lizards" />
+  <meta property="og:url" content="https://lizards.opensuse.org" />
+  <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
+
+  <!-- include JS from static.opensuse.org -->
+  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
+  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
+  <!-- This is for local development:
+  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
+  -->
+
+  <!-- translated global navigation -->
+  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
+  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
+
+  <!-- social service scripts -->
+  <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
+  <script type="text/javascript">
+ 	 (function() 
+		{
+  	  		var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
+    			po.src = 'https://apis.google.com/js/plusone.js';
+    			var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+  		})();
+  </script>
+
+  <link rel="alternate" type="application/rss+xml" href="https://lizards.opensuse.org/feed/" title="openSUSE Lizards latest posts" />
+  <link rel="alternate" type="application/rss+xml" href="https://lizards.opensuse.org/comments/feed/" title="openSUSE Lizards latest comments" />
+  <link rel="pingback" href="https://lizards.opensuse.org/xmlrpc.php" />
+  
+    <link rel='dns-prefetch' href='//s.w.org' />
+		<script type="text/javascript">
+			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/lizards.opensuse.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.6.1"}};
+			!function(a,b,c){function d(a){var c,d,e,f,g,h=b.createElement("canvas"),i=h.getContext&&h.getContext("2d"),j=String.fromCharCode;if(!i||!i.fillText)return!1;switch(i.textBaseline="top",i.font="600 32px Arial",a){case"flag":return i.fillText(j(55356,56806,55356,56826),0,0),!(h.toDataURL().length<3e3)&&(i.clearRect(0,0,h.width,h.height),i.fillText(j(55356,57331,65039,8205,55356,57096),0,0),c=h.toDataURL(),i.clearRect(0,0,h.width,h.height),i.fillText(j(55356,57331,55356,57096),0,0),d=h.toDataURL(),c!==d);case"diversity":return i.fillText(j(55356,57221),0,0),e=i.getImageData(16,16,1,1).data,f=e[0]+","+e[1]+","+e[2]+","+e[3],i.fillText(j(55356,57221,55356,57343),0,0),e=i.getImageData(16,16,1,1).data,g=e[0]+","+e[1]+","+e[2]+","+e[3],f!==g;case"simple":return i.fillText(j(55357,56835),0,0),0!==i.getImageData(16,16,1,1).data[0];case"unicode8":return i.fillText(j(55356,57135),0,0),0!==i.getImageData(16,16,1,1).data[0];case"unicode9":return i.fillText(j(55358,56631),0,0),0!==i.getImageData(16,16,1,1).data[0]}return!1}function e(a){var c=b.createElement("script");c.src=a,c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var f,g,h,i;for(i=Array("simple","flag","unicode8","diversity","unicode9"),c.supports={everything:!0,everythingExceptFlag:!0},h=0;h<i.length;h++)c.supports[i[h]]=d(i[h]),c.supports.everything=c.supports.everything&&c.supports[i[h]],"flag"!==i[h]&&(c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&c.supports[i[h]]);c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&!c.supports.flag,c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.everything||(g=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",g,!1),a.addEventListener("load",g,!1)):(a.attachEvent("onload",g),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),f=c.source||{},f.concatemoji?e(f.concatemoji):f.wpemoji&&f.twemoji&&(e(f.twemoji),e(f.wpemoji)))}(window,document,window._wpemojiSettings);
+		</script>
+		<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+<link rel='https://api.w.org/' href='https://lizards.opensuse.org/wp-json/' />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://lizards.opensuse.org/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://lizards.opensuse.org/wp-includes/wlwmanifest.xml" /> 
+<meta name="generator" content="WordPress 4.6.1" />
+<script type='text/javascript' src='https://lizards.opensuse.org/wp-content/plugins/anti-captcha/anti-captcha-0.3.js.php?ver=91a575b38c7c4526decc579655a2a49c'></script>
+<style type="text/css">
+.avatar {vertical-align:middle}
+.credit {font-size: 50%;}
+</style>
+		  
+  <link rel="icon" type="image/png" href="//static.opensuse.org/themes/bento/images/favicon.png" />
+  <title>openSUSE Lizards</title>
+  
+</head>
+
+<body>
+  
+  <!-- include header from static -->
+    
+  <!-- Start: Header -->
+  <div id="header">
+    
+    <div id="header-content" class="container_12">
+      
+      <a id="header-logo" href="http://www.opensuse.org">
+        <img src="//static.opensuse.org/themes/bento/images/header-logo.png" width="46" height="26" alt="Header Logo" />
+      </a>
+      
+            
+            <ul id="global-navigation">
+        <li id="item-downloads"><a href="http://opensuse.org/sitemap#downloads">Downloads</a></li>
+        <li id="item-support"><a href="http://opensuse.org/sitemap#support">Support</a></li>
+        <li id="item-community"><a href="http://opensuse.org/sitemap#community">Community</a></li>
+        <li id="item-development"><a href="http://opensuse.org/sitemap#development">Development</a></li>
+      </ul>
+      
+      
+<form role="search" method="get" id="searchform" action="https://lizards.opensuse.org" >
+  <div>
+    <!-- TODO: use Label as action indicator ==> JS needed -->
+    <label class="screen-reader-text layer-label" for="s">Search</label>
+    <input type="text" value="" name="s" id="s" />
+    <input type="submit" id="searchsubmit" class="hidden" value="Search" />
+  </div>
+</form>    
+    </div>
+  </div>
+  <!-- End: Header -->
+
+  <div id="subheader" class="container_12">
+    <div id="breadcrump" class="grid_8 alpha">
+      <a href="/"><img src="//static.opensuse.org/themes/bento/images/home_grey.png" width="16" height="16" alt="Home" /></a> <a class="navCrumb lnk" href="https://lizards.opensuse.org">Home</a>    </div>
+    
+          
+          <div class="grid_4" id="login-wrapper">
+        <a href="#signup-page">Sign up</a> | 
+        <!-- <a id="login-trigger" href="" title="Login">Login</a> -->
+        <!-- wp_login_form() ==> http://codex.wordpress.org/Function_Reference/wp_login_form -->
+        <a href="https://lizards.opensuse.org/wp-login.php" title="Login">Login</a>
+      </div>
+      </div>
+
+<!-- Start: Main Content Area -->
+<div id="content" class="container_16 content-wrapper">
+  <!-- <div id="highlight-wrapper" class="box box-shadow grid_12 alpha">
+
+            
+  </div> -->
+  
+  <div class="box box-shadow grid_12 alpha main">
+
+    <!-- <div id="test" style="background-color: #111; height: 6px; overflow: hidden; margin-top: -15px; -moz-border-radius-topleft: 5px; -moz-border-radius-topright: 5px;"> </div> -->
+                
+    
+      
+        <div class="post-11983 post type-post status-publish format-standard hentry category-base-system category-distribution category-documentation category-factory category-hackweek category-programming category-systems-management category-yast" id="post-11983">
+          <h2><a href="https://lizards.opensuse.org/2016/09/28/highlights-of-yast-development-sprint-25/" rel="bookmark" title="Permanent Link to Highlights of YaST development sprint 25">Highlights of YaST development sprint 25</a></h2>
+          <small>September 28th, 2016 by <a href="https://lizards.opensuse.org/author/yast-team/" title="Posts by Yast Team" rel="author">Yast Team</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/09/28/highlights-of-yast-development-sprint-25/"
+                data-text="openSUSE News: Highlights of YaST development sprint 25"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F09%2F28%2Fhighlights-of-yast-development-sprint-25%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <p>Another development sprint is over. Time flies! In our <a href="https://lizards.opensuse.org/2016/09/07/highlights-of-yast-development-sprint-24/">previous post</a> we already reported about the branching of Tumbleweed and the upcoming releases and about the expected consequences: the landing of some cool features in a less conservative Tumbleweed.</p>
+<p>We are still dedicating quite some effort to polish the upcoming stable releases (SLE12-SP2 and Leap 42.2), but in this sprint we finally found some time to play. Which is great because blogging about new features is more fun than doing it about bug fixes. 🙂</p>
+<h3>Importing Authorized Keys with AutoYaST</h3>
+<p>When logging in via SSH, public key authentication should be preferred over password authentication. Until now, the best way of setting up the required authorized_keys files in AutoYaST was using the files section.</p>
+<p>However, that approach is tedious and error prone, as you need to make sure you set the correct owner, permissions, etc. Moreover you need to keep in sync the user definition (username and home directory) with the file definition.</p>
+<p>AutoYaST now supports the specification of a set of public keys for each user with a pretty straightforward syntax:</p>
+<pre>
+&lt;user&gt;
+  &lt;username&gt;suse&lt;username&gt;
+  &lt;authorized_keys config:type="list"&gt;
+    &lt;listentry&gt;ssh-rsa your-public-key-1&lt;/listentry&gt;
+    &lt;listentry&gt;ssh-rsa your-public-key-2&lt;/listentry&gt;
+  &lt;authorized_keys&gt;
+&lt;user&gt;
+</pre>
+<p>AutoYaST takes care of writing the files and setting the ownership and the proper permissions.</p>
+<p>While documenting this new feature we realized the AutoYaST documentation about users management could be more detailed, which leads us to&#8230;</p>
+<h3>Improving the documentation</h3>
+<p>Usually developers love to create programs loaded with cool features but hate to write documentation. Fortunately there are people out there who enjoy writing documentation and bringing all those features to light. We have already mentioned in previous reports how grateful we are for having the SUSE documentation team polishing and publishing our documentation drafts and how open and straightforward the process is.</p>
+<p>We updated the YaST documentation to include information about the installer self-update feature, which will debut in SUSE Linux Enterprise 12 SP2 and openSUSE Leap 42.2. As part of <a href="https://github.com/SUSE/doc-sle/pull/69">the same pull request</a> and in the AutoYaST side, some additional improvements were made, including cleaning-up some duplicated information about SUSE registration.</p>
+<p>On the other hand and as a consequence of the above mentioned new feature, the AutoYaST documentation regarding users management has been rewritten adding missing information like groups, user defaults and login settings.</p>
+<p>All our pull requests are already merged in the <code>doc-sle</code> repository. At a later point in time, the SUSE documentation team will review and polish all the new content (including ours) and will publish an up-to-date version of the online documentation. If you don&#8217;t want to wait, you can easily generate an HTML or PDF version of the documentation including all the non-reviewed contributions just following the very simple instructions in the <a href="https://github.com/SUSE/doc-sle/blob/develop/README.adoc">README file</a> of the <code>doc-sle</code> repository.</p>
+<p>Did we already mention we love the open source, programmer-friendly processes of the documentation team? 😉</p>
+<h3>Storage reimplementation: something you can touch</h3>
+<p>We promised news about the storage reimplementation and here they are. Our customized Tumbleweed image (labeled as NewStorage) in the <a href="http://download.opensuse.org/repositories/YaST:/storage-ng/images/iso/">storage-ng OBS repository</a> can now perform some simple actions during installation and display the result to the user.</p>
+<p>First of all, when proposing the timezone settings it will, as usual, check for MS Windows installations in the disk to guess if the hardware clock should be set to UTC. The news is that check is performed using the new storage stack, that offers more functionality in every sprint.</p>
+<p>More important is that the installer will show the partitioning proposal calculated also using the new stack. As you can see in the screenshot below, the screen is way more simpler than the one you would find in a regular Tumbleweed. There are no buttons to change the settings or to run the expert partitioner yet. That doesn&#8217;t mean the functionality is not there, it&#8217;s simply that we prefer to focus first on modifying all the installer steps to use the new stack (what will enable us to use openQA) before refining every screen to add all options there.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/sp.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/sp-300x244.png" alt="The new partitioning proposal" width="300" height="244" class="aligncenter size-medium wp-image-11987" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/sp-300x244.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/09/sp-768x624.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/sp-1024x833.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/09/sp.png 1038w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Right now the system works only in disks containing a MS-DOS style partition table and will always propose a partition-based (no LVM) setup. That&#8217;s because we prefer to solve the hardest scenarios first. Using LVM and/or GPT partition tables is less challenging than the already supported scenario.</p>
+<h3>Reduce global warming by saving OBS build power</h3>
+<p>As you may know, we use the awesome <a href="http://openbuildservice.org/">Open Build Service</a> (OBS) to generate both the YaST rpm packages and the openSUSE/SLE ISO images. Every time the source code of any component changes, OBS rebuilds that component and all the packages that depend on it.</p>
+<p>Our beloved openSUSE and SLE release managers told us that there were several YaST packages that often triggered rebuild of other YaST packages, that triggered yet another rebuild, that triggered&#8230; you got the idea. 😉</p>
+<p>The mentioned problem slows down the creation of new ISO images, interferes with the continuous integration process (specially visible in Tumbleweed) and wastes valuable OBS resources.</p>
+<p>During this sprint <b>we reduced the rebuild time of YaST by 30%</b>. That&#8217;s for sure interesting, but knowing the details about how we did it could be even more interesting for many readers. We feared the explanation could be too complex and technical to fit into this report&#8230; which gives us just another opportunity for blogging. So expect an upcoming post including interesting technical stuff and crazy graphs like this one.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-184x300.png" alt="YaST dependencies graph" width="184" height="300" class="aligncenter size-medium wp-image-11989" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-184x300.png 184w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-768x1255.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after-627x1024.png 627w, https://lizards.opensuse.org/wp-content/uploads/2016/09/yast_deps_after.png 1600w" sizes="(max-width: 184px) 100vw, 184px" /></a></p>
+<h3>Some adjustment for the installer in the LiveCDs</h3>
+<p>One of the good things about working in open source is that sometimes the evolution of the projects you have created can surprise you. Quite some time ago, the YaST team dropped support for the live installer. It was simply too demanding to keep it alive while still doing our regular work (bug fixes and new features for YaST and the regular installer).</p>
+<p>Recently the live installer was removed from Tumbleweed, the only system in which it was still available (after having been dropped in the past from stable openSUSE releases). One could have expected that somebody would decide then to step up and take the maintainership of the live installer.</p>
+<p>But what actually happened was that Fabian Vogt decided to try a different approach we haven&#8217;t considered &#8211; adding the standard network installer to the LiveCDs images of Tumbleweed. He managed to make it work well enough and asked us for help to debug some problems. We fixed the initial problems by disabling the self-update functionality in the LiveCDs (it&#8217;s simply not designed to work on that scenario).</p>
+<p>There are still quite some problems to be resolved to make everything work flawlessly, but if Fabian and others don&#8217;t give up, we will keep assisting them in order to bring the installation back to the LiveCDs&#8230; even in unexpected ways.</p>
+<h3>UI Designer</h3>
+<p>The YaST user interface is quite difficult to design and code. The main problem is that there <del>is</del> was no interactive UI designer where you could build a dialog or modify an existing one. Instead, you had to write new code or modify the existing code which creates and opens the dialog. Then, to see your changes you had to start the YaST module, go to the respective dialog and check its content. If it didn&#8217;t look like you intended, you had to close it, modify the code and start it again. And again&#8230; and again. Very annoying especially if the dialog is hidden deep in the module and you need to take several steps to get there.
+</p>
+<p>
+During Hack Week 14, <a href="https://hackweek.suse.com/14/projects/1522">a project to improve the situation a bit</a> was started. We already had a dialog spy which can be opened by Ctrl+Shift+Alt+Y keyboard shortcut, but that was read-only. You could only inspect the dialog tree and see the details of the selected widget but you could not change anything.
+</p>
+<p>During that Hack Week project it was improved so it could edit the properties of the existing widgets, remove them or even add some new widgets. However the code was more or less a proof of concept than ready to be merged into the YaST UI and released to public. So we decided to finish it in this sprint.</p>
+<p>As usual, it was harder than expected&#8230; but we made it and here is a short demo showing how it works and what you can do there:</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/ui-designer.gif" alt="The new UI designer in action" /></p>
+<p>The new tool is still far from being perfect. The most obvious missing feature is that the dialog is changed in place and you cannot save or export you changes. After closing the dialog everything is lost. But it can still help to try things in the UI or make a quick prototype, specially when discussing solutions with interface designers. Hopefully we find some more time in the future to make it even better.</p>
+<h3>Storage reimplementation: encryption support</h3>
+<p>Although the partitioning proposal still does not support encryption or LVM, we implemented full LUKS (encryption) support in the underlying library (libstorage-ng). Together with the LVM support implemented in the previous sprint, that makes the new library already a valid replacement for the old libstorage in many situations and scenarios. Now it&#8217;s mainly a matter of switching from one version to another in every single YaST component, starting with the expert partitioner that we plan to start redesigning in the next sprint.</p>
+<p>As usual, new features in the library are hard to illustrate, unless you accept the action diagrams as screenshots. In that case, here you can see the sequence of actions performed by the library when creating an encrypted home volume.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/create.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/create-293x300.png" alt="Creation of an encrypted home with libstorage-ng" width="293" height="300" class="aligncenter size-medium wp-image-11995" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/create-293x300.png 293w, https://lizards.opensuse.org/wp-content/uploads/2016/09/create.png 508w" sizes="(max-width: 293px) 100vw, 293px" /></a></p>
+<h3>Syncing keyboard layouts and console fonts in Leap and Tumbleweed</h3>
+<p>In parallel to our Scrum sprints, we have been for some time steady working, together with the openSUSE maintainers of X.Org and systemd, in redesigning how keyboard maps and console fonts are managed by YaST. Some changes were introduced in Tumbleweed some time ago but never made it to SLE (or Leap) because they needed more testing.</p>
+<p>Recently Ludwig Nussel, the Leap&#8217;s release manager, decided that he wanted to sync 42.2 with Tumbleweed in that regard, using the new approach instead of the more conservative SLE one. Thus, we also invested quite some time coordinating again with Stefan Dirsch (X.Org) and Franck Bui (systemd) to push the changes just in time for the beta2 version of Leap 42.2&#8230; just in time to introduce <a href="https://bugzilla.suse.com/show_bug.cgi?id=1000565">bug#1000565</a>, that was honored with its inclusion in the list of <a href="https://en.opensuse.org/openSUSE:Most_annoying_bugs_42.2_dev">most annoying bugs</a> in 42.2 Beta2.</p>
+<p>The bright side is that a fix for the bug has already been provided (see bug report) and you can now finally test the new fonts and keyboard maps. Please, do so and provide feedback in order to get a properly localized Leap 42.2 release.</p>
+<h3>See you soon</h3>
+<p>As usual, this post was just a quick overview of the most interesting part of the sprint, because most people (including ourselves) don&#8217;t want to read about the boring part of the work, which is mainly fixing bugs.</p>
+<p>The good news is that this time you will not have to wait another three weeks to read interesting stuff about YaST. As mentioned, we plan to publish a blog post about the reduction of the build time of YaST. And we will probably also publish a post about the visit of a YaST geecko to <a href="http://euruko2016.org/">Euruko 2016</a>.</p>
+<p>So this time more than ever&#8230; stay tuned!</p>
+          </div>
+
+          <p class="postmetadata"> Posted in <a href="https://lizards.opensuse.org/category/base-system/" rel="category tag">Base System</a>, <a href="https://lizards.opensuse.org/category/distribution/" rel="category tag">Distribution</a>, <a href="https://lizards.opensuse.org/category/documentation/" rel="category tag">Documentation</a>, <a href="https://lizards.opensuse.org/category/distribution/factory/" rel="category tag">Factory</a>, <a href="https://lizards.opensuse.org/category/hackweek/" rel="category tag">Hackweek</a>, <a href="https://lizards.opensuse.org/category/programming/" rel="category tag">Programming</a>, <a href="https://lizards.opensuse.org/category/systems-management/" rel="category tag">Systems Management</a>, <a href="https://lizards.opensuse.org/category/systems-management/yast/" rel="category tag">YaST</a> |   <a href="https://lizards.opensuse.org/2016/09/28/highlights-of-yast-development-sprint-25/#respond">No Comments &#187;</a></p>
+        </div>
+
+      
+        <div class="post-11959 post type-post status-publish format-standard hentry category-distribution category-factory category-gsoc-2 category-programming category-systems-management category-yast" id="post-11959">
+          <h2><a href="https://lizards.opensuse.org/2016/09/07/highlights-of-yast-development-sprint-24/" rel="bookmark" title="Permanent Link to Highlights of YaST development sprint 24">Highlights of YaST development sprint 24</a></h2>
+          <small>September 7th, 2016 by <a href="https://lizards.opensuse.org/author/yast-team/" title="Posts by Yast Team" rel="author">Yast Team</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/09/07/highlights-of-yast-development-sprint-24/"
+                data-text="openSUSE News: Highlights of YaST development sprint 24"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F09%2F07%2Fhighlights-of-yast-development-sprint-24%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <p>We are back to this blog after another three weeks of (mainly) bug-fixing. In the <a href="https://lizards.opensuse.org/?p=11935">previous post</a> we promised some news about the self-update functionality and about the LVM support in the new storage stack. We have that&#8230; and much more!</p>
+<p>So this will be a long post, but it also hides some gems. You will have to keep reading in order to find them.</p>
+<h3>Self-update improvements</h3>
+<p>We have already mentioned in several previous reports the new self-update feature in YaST, which allows updating the installer itself before performing installation of the system.</p>
+<p>But it turned out that the initial implementation had an important drawback. The self-update process happened after having performed some of the installation steps. Then, after updating the installer it was restarted and several of those steps lost their configuration or simply did their operations twice.</p>
+<p>After some discussions we decided to move the self-update step earlier, at the very beginning. For downloading the updates we basically need just working network connection and initialized package management. So we moved the self-update step after the initial automatic network setup (DHCP) and added package initialization to the self-update step.</p>
+<p><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/c9d6beac-6e93-11e6-853b-62063269b7dd.gif" alt="The self-update in action" /></p>
+<p>As you can see the self-update step is the very first step in the installation workflow, the language selection and the EULA dialog is displayed <i>after</i> the self update is finished and YaST is restarted. That means all the following steps do not need to remember their state as they will not be called twice after the restart.</p>
+<p>The disadvantage is that we had to drop some features. The self-update step happens before the language selection and the optional disk activation. That means by default the self-update progress (and potential error messages) will be displayed in English. But you can still use the &#8220;language&#8221; boot option and set the language manually via <i>linuxrc</i>.</p>
+<p>On the bright side, we fixed like half a dozen of reported bugs just by relocating the self-update process. So we are pretty sure it&#8217;s worth the price.</p>
+<p>For more details see the updated <a href="https://github.com/yast/yast-installation/blob/master/doc/SELF_UPDATE.md">documentation</a>.</p>
+<h3>Gem one: using the <code>info</code> boot parameter</h3>
+<p>The <code>info</code> boot parameter is a pretty old <i>linuxrc</i> option but it is probably not known well. The parameter is an URL which points to a text file which can contain more boot options.</p>
+<p>When we tested the updated self-update described above we needed to build a driver update disk and pass several boot options. To avoid repeating the same options on the boot command line and to share the boot options across the team we created an <code>info.txt</code> file with content like</p>
+<pre>
+insecure=1
+startshell=1
+dud=ftp://example.com/self_update.dud
+</pre>
+<p>Then you simply boot the installation with <code>info=ftp://example.com/info.txt</code> and <i>linuxrc</i> will read the additional parameters from the file. This can save you a lot of typing, especially if you need to repeat the tests many times.</p>
+<h3>Fixed a security bug for 7 (yes, seven) different SLE releases</h3>
+<p>Some weeks ago, during a routine code review, our security experts found a vulnerability in YaST&#8217;s libstorage related to the way we provide the encryption passwords to some external commands. It is debatable how dangerous this threat really is. It was never a problem during system installation, but it would affect admins who create encrypted partitions (mostly encrypted LVM physical volumes) or crypto files in the installed system.</p>
+<p>A potential attacker with access to <code>/tmp</code> could intercept the password in the very precise moment in which the &#8220;cryptsetup&#8221; or &#8220;losetup&#8221; command are invoked by YaST. It&#8217;s really only a matter of milliseconds. But we don&#8217;t want to take any risks, however small they may be.</p>
+<p>So not only did we fix that for the current code streams, we backported it to all the SLE releases out there that are still supported (even though in some cases it&#8217;s just a single customer) &#8211; back to SLES-10 SP3 from late 2009. That meant backporting the fix to no less than 7 SLE releases (for Leap, those fixes are picked automatically).</p>
+<p>As you can imagine, this got more difficult the farther back in history we went: In a central library like libstorage, things are constantly changing because the tools and environment (kernel, udev, you name it) are constantly changing. There was only a single case where the patch applied cleanly; in all other cases, it involved massive manual work (including testing, of course).</p>
+<p>Was this fun? No, it certainly was not. It was a tedious and most frustrating experience. Do we owe it to our users (paying customers as well as community users) to fix security problems, however theoretical they are? Yes, of course. That&#8217;s why we do those things.</p>
+<h3>Storage reimplementation: every LVM piece in its place</h3>
+<p>As time permits, we keep adding new features to the future libstorage replacement. During previous sprints we added support to read and manipulate all kinds of LVM block devices (PVs, VGs and LVs) but an important aspect was missing: deciding the order of the operations is as important as performing them. We instructed the library about the dependencies between operations and implemented several automated test cases to ensure we don&#8217;t try to do not-so-smart things like removing a physical volume from a volume group and shrinking its logical volumes <i>afterwards</i>.</p>
+<p>The good thing about our automated test-cases is that they generate nice graph that are quite useful to illustrate blog posts. 🙂</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action-300x48.png" alt="One of the several added test-cases" width="300" height="48" class="aligncenter size-medium wp-image-11972" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action-300x48.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action-768x122.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action-1024x163.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/09/complex1-action.png 1531w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Gem two: enjoy Google Summer of Code result</h3>
+<p>As you may know, openSUSE is one of the Free Software organizations selected to take part in Google Summer of Code 2016. For YaST that means we had the huge pleasure of having Joaquín Yeray as student. You can know more about him and his experience diving into YaST and Open Source in <a href="https://joaquinyeray.me/">his GSoC blog</a>. </p>
+<p>But the openSUSE community is not only gaining a new member, we also have a new YaST module. The <a href="https://software.opensuse.org/package/yast2-alternatives">yast2-alternatives</a> package has already been accepted into Tumbleweed and will be also part of Leap 42.2. So we have a new gadget in our beloved configuration Swiss Army knife!</p>
+<p>We liked Joaquín and his module so much that we are revamping the YaST development tutorial to be based on his module (instead of yast2-journal). He is already working on that, so hopefully we will have Joaquín around quite some time still. 😉</p>
+<h3>Unify license handling screens</h3>
+<p>We got a report about the license agreement screen in automatic installation (AutoYaST) being different to the one showed during common installation. So we decided to take a look to the problem and unify them. We are in a quite late phase of the development process of both the next SLE and the next Leap, so we decided to not unify the code but simply adapt one dialog to look like the other. Also we are after string freeze due to translations, so we had to use a trick and reuse another already translated text. We also took the opportunity to fix some small usability problems.</p>
+<p>This is one of those cases in which some images are worth a thousand words, so in order to understand what we did, take a look at the description of <a href="https://github.com/yast/yast-packager/pull/185">this pull request</a>, which includes many images (too many for this blog post).</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864-300x230.png" alt="The new AutoYaST license screen" width="300" height="230" class="aligncenter size-medium wp-image-11965" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864-300x230.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864-768x588.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864-1024x784.png 1024w, https://lizards.opensuse.org/wp-content/uploads/2016/09/1c218406-693c-11e6-9c81-578b7ce30864.png 1040w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Smarter check to avoid duplicated repositories</h3>
+<p>The openSUSE software server defines the online repositories which can be added during installation. The openSUSE DVD also specifies its own online repositories that are always added to the system. And these repositories overlap.</p>
+<p>In openSUSE 42.1 it happened that one repository was added twice, even though there was already a check to avoid that. So we investigated why.</p>
+<p>We found that the URLs for the problematic repository were not exactly the same, one of them had a trailing slash. Therefore we made the URL comparison more tolerant and if the URLs differ only by the trailing slash, they are still considered the same.</p>
+<p>After the fix all repositories are added only once, without any duplicates.</p>
+<h3>Gem three: we are looking for new teammates!</h3>
+<p>After 12 sprint reports, most readers would have already realized that the life as a full-time YaST developer is everything but boring&#8230; and that we are always pretty busy. The fun and the work are better when you share them so&#8230; <a href="https://jobs.suse.com/job/nuremberg/linux-c-ruby-hero-global-location/3486/2930771">we are looking for a new hero</a> to join us in our journey.</p>
+<p>Even if you don&#8217;t feel hacking in YaST would be your thing, maybe you are interested in any of the other <a href="https://www.suse.com/company/careers">jobs at SUSE</a>.</p>
+<h3>Improved documentation about YaST environment variables</h3>
+<p>The behaviour of YaST can be affected by several environment variables, but not all of them are well known by everybody. During this sprint we also decided to invest some time documenting them better. The resulting document will be soon properly integrated in our <a href="http://yast.github.io/documentation.html">centralized documentation for developers</a>, but you can sneak it already <a href="https://github.com/yast/yast.github.io/blob/master/doc/environment-variables.md">here</a>.</p>
+<h3>Branching Tumbleweed and the upcoming stable releases</h3>
+<p>Most of the features and bug-fixes we have blogged about in the last months were incorporated to Tumbleweed, the upcoming Leap 42.2 and the future SLE 12-SP2, since we always try to keep those three codebases as close as possible to each other.</p>
+<p>Now Leap 42.2 and SLE 12-SP2 are close enough to their release date, so we plan to be more conservative with the changes. At the end of this sprint we decided to branch the code for Tumbleweed and for the stable siblings. From now on, most exciting stuff will appear only in Tumbleweed, with SLE 12-SP2 and Leap 42.2 becoming more and more boring.</p>
+<h3>And the wheel keeps on turning</h3>
+<p>So that was a very minimal selection of the most interesting stuff from the just finished sprint. What comes next? Another sprint, of course! We have already planned some interesting stuff for it, like integrating the new partitioning proposal into the installer or finishing the <a href="https://hackweek.suse.com/14/projects/1522">ultra-cool UI designer</a> that was started during latest Hack Week.</p>
+<p>As always, you can follow development in a daily basis in the usual channels (<a href="irc://irc.opensuse.org/yast">#yast IRC channel</a> and the <a href="https://lists.opensuse.org/yast-devel/">yast-devel</a> mailing list) or wait another three weeks for the next sprint report. Meanwhile&#8230; have a lot of fun!</p>
+          </div>
+
+          <p class="postmetadata"> Posted in <a href="https://lizards.opensuse.org/category/distribution/" rel="category tag">Distribution</a>, <a href="https://lizards.opensuse.org/category/distribution/factory/" rel="category tag">Factory</a>, <a href="https://lizards.opensuse.org/category/gsoc-2/" rel="category tag">GSOC</a>, <a href="https://lizards.opensuse.org/category/programming/" rel="category tag">Programming</a>, <a href="https://lizards.opensuse.org/category/systems-management/" rel="category tag">Systems Management</a>, <a href="https://lizards.opensuse.org/category/systems-management/yast/" rel="category tag">YaST</a> |   <a href="https://lizards.opensuse.org/2016/09/07/highlights-of-yast-development-sprint-24/#respond">No Comments &#187;</a></p>
+        </div>
+
+      
+        <div class="post-11935 post type-post status-publish format-standard hentry category-distribution category-documentation category-factory category-programming category-systems-management category-yast" id="post-11935">
+          <h2><a href="https://lizards.opensuse.org/2016/08/18/highlights-of-yast-development-sprint-23/" rel="bookmark" title="Permanent Link to Highlights of YaST development sprint 23">Highlights of YaST development sprint 23</a></h2>
+          <small>August 18th, 2016 by <a href="https://lizards.opensuse.org/author/yast-team/" title="Posts by Yast Team" rel="author">Yast Team</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/08/18/highlights-of-yast-development-sprint-23/"
+                data-text="openSUSE News: Highlights of YaST development sprint 23"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F08%2F18%2Fhighlights-of-yast-development-sprint-23%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <p>As already mentioned in our <a href="https://lizards.opensuse.org/?p=11893">previous blog post</a>, with Leap 42.2 in Alpha phase and SLE12-SP2 in Beta phase, the YaST Team is concentrating the firepower in fixing bugs in the installer. We fixed more than 40 bugs in three weeks! The dark side is that most bug fixes are not juicy enough for writing a blog post&#8230; but there is always some interesting stuff to report.</p>
+<h3>Integration of installer self-update with SCC and SMT</h3>
+<p>The installer self-update feature integrates now with <a href="https://scc.suse.com">SUSE Customer Center (SCC)</a> and <a href="https://www.suse.com/products/subscription-management-tool">Subscription Management Tool (SMT)</a> servers. Until now, there were three different mechanisms to get the URL of the installer updates repository:</p>
+<ul>
+<li>User defined (using the `SelfUpdate` boot option).</li>
+<li>Using an AutoYaST profile.</li>
+<li>The default one, specified in the `control.xml` which is shipped in the media.</li>
+</ul>
+<p>Now YaST2 is able to ask for the repository URL to SCC/SMT servers. The details of how the URL is determined are <a href="https://github.com/yast/yast-installation/blob/master/doc/SELF_UPDATE.md#where-to-find-the-updates">documented in the repository</a>.</p>
+<h3>Fixes and enhanced usability in dialogs with timeout</h3>
+<p>As you may know, it&#8217;s possible to install (open)SUSE in an automatic, even completely unattended, basis using AutoYaST. AutoYaST can be configured to display custom configuration dialogs to the user and wait for the reply a certain amount of time before automatically selecting the default options. Until now, the only way for the user to stop that countdown was to start editing some of the fields in the dialog.</p>
+<p>We got a bug report because that functionality was not working exactly as expected in some cases so, in addition to fixing the problem, we decided to revamp the user interface a little bit to improve usability. Now there are more user interactions that are taken into account to stop the counter, specially we added a new &#8220;stop&#8221; button displaying the remaining seconds. You can see an example of the result below.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/08/06449188-55a9-11e6-9461-dfc352fff8d8.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/08/06449188-55a9-11e6-9461-dfc352fff8d8-300x199.png" alt="New layout for dialogs with timeout" width="300" height="199" class="aligncenter size-medium wp-image-11944" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/08/06449188-55a9-11e6-9461-dfc352fff8d8-300x199.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/08/06449188-55a9-11e6-9461-dfc352fff8d8.png 682w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Following, as usual, the Boy Scout Rule we also took the opportunity to add automated tests to make that part of YaST more robust for the future.</p>
+<h3>Automatically integrating add-on repositories during installation</h3>
+<p>Sometimes you want to extend the regular installation media by adding just a few extra packages or provide a number of fixed packages along with the media.</p>
+<p>For this purpose, the installer can automatically register an add-on repository. All you have to do is to put the repository on the installation medium and to add a file <code>/add_on_products.xml</code> that points to this repository.</p>
+<p>The file looks like this:</p>
+<pre>
+&lt;?xml version="1.0"?&gt;
+&lt;add_on_products xmlns="http://www.suse.com/1.0/yast2ns"
+    xmlns:config="http://www.suse.com/1.0/configns"&gt;
+    &lt;product_items config:type="list"&gt;
+        &lt;product_item&gt;
+            &lt;name&gt;My Add-on&lt;/name&gt;
+            &lt;url&gt;relurl://myaddon?alias=MyAddon&lt;/url&gt;
+            &lt;priority config:type="integer"&gt;70&lt;/priority&gt;
+            &lt;ask_user config:type="boolean"&gt;false&lt;/ask_user&gt;
+            &lt;selected config:type="boolean"&gt;true&lt;/selected&gt;
+            &lt;check_name config:type="boolean"&gt;false&lt;/check_name&gt;
+        &lt;/product_item&gt;
+    &lt;/product_items&gt;
+&lt;/add_on_products&gt;
+</pre>
+<p>You can define the following elements:</p>
+<ul>
+<li><code>&lt;name&gt;</code> is the name of your repository</li>
+<li><code>&lt;url&gt;</code> points the the repository location; you&#8217;ll likely want to use the <code>relurl</code> scheme here that gives the location relative to the main installation repository</li>
+<li><code>&lt;priority&gt;</code> is the repository priority (lesser number means higher priority, the main installation repository has priority 99)</li>
+<li><code>&lt;ask_user&gt;</code>: should the user be asked about adding the repository?</li>
+<li><code>&lt;selected&gt;</code>: should the repository be automatically selected?</li>
+<li><code>&lt;check_name&gt;</code>: should the repository&#8217;s actual name be matched against the value of the <code>&lt;name&gt;</code> element?</li>
+</ul>
+<p>You can of course list several repositories in this file.</p>
+<p>If you&#8217;re too lazy to remember all this, <a href="https://software.opensuse.org/package/mksusecd">mksusecd</a> can do all this for you.</p>
+<p>For example, if you have a set of new kernel packages you would like to use, do:</p>
+<pre>
+mksusecd --create new.iso --addon kernel-*.rpm --addon-name 'my kernel' sles12-sp2.iso
+</pre>
+<p>This creates a new iso based on <code>sles12-sp2.iso</code> that will install your new kernel packages instead.</p>
+<h3>Storage reimplementation: small steps for the code, giant leap for continuous integration</h3>
+<p>During bug squashing we managed to find some time to keep the storage stack reimplementation rolling&#8230; slow and steady. The customized Tumbleweed images (labeled as NewStorage) in the <a href="http://download.opensuse.org/repositories/YaST:/storage-ng/images/iso/">storage-ng OBS repository</a> are already able to analyze most systems, creating a representation of the system storage devices in memory that will be used to manipulate the disks and propose a partitioning schema. Unfortunately, this representation is only visible in the YaST logs since fixing installer bugs was more urgent than representing that information in the UI.</p>
+<p>This turned to be an important milestone, not because of the functionality itself or the value of the code (we just added a couple of lines of Ruby code), but because for the first time the dependencies in some packages were switched from libstorage to libstorage-ng. That had important implications for the code organization and for our continuous integration infrastructure, specially the <a href="https://travis-ci.org/">Travis CI</a> integration, which implies the generation of .deb packages. We can now say that our continuous delivery workflow (from Github to OBS, passing through Jenkins, Travis, Coveralls and Code Climate) is free of any trace of the old storage code.</p>
+<p>In addition, we also did some good progress in LVM support in the new library, being able to recognize and manipulate in memory all kind of LVM structures.</p>
+<h3>The joy of openness: updating the SUSE Linux Enterprise documentation</h3>
+<p>An important part of our job, specially as a new release date approaches, is helping to shape the SUSE Linux Enterprise (SLE) documentation. One of the strongest points of SUSE products is the awesome SUSE&#8217;s documentation team which, as the rest of the company, have open source in their genes. Suggesting improvements and updates for the documentation is as straightforward as creating a pull request in the completely open <a href="https://github.com/SUSE/doc-sle/">documentation repository at Github</a>&#8230; and anybody can do it!</p>
+<p>The documentation team uses Docbook, but they would accept contributions in other formats (e.g. Markdown) and transform it themselves into Docbook&#8230; just because they are that cool. 🙂</p>
+<h3>Better support for ARM systems using EFI</h3>
+<p>The world is getting full of cool ARM64 devices and both SUSE and openSUSE are actively working in supporting as many of them as possible. We took another small step during this sprint improving the installer&#8217;s partitioning proposal for ARM systems that use EFI.</p>
+<h3>That&#8217;s not all, folks</h3>
+<p>As we always say, this was just the small portion of the work done that we consider exciting enough to be part of our development reports, since we don&#8217;t want to bore you with details about every single fixed bug. During this installer bug-fixing phase, this is more true than ever and the next sprint, which is already planned, will be similar to this in that regard. Nevertheless, in the next report we expect to have some interesting news about the installer self-update functionality and about the LVM support in the new storage stack. Stay tuned.</p>
+          </div>
+
+          <p class="postmetadata"> Posted in <a href="https://lizards.opensuse.org/category/distribution/" rel="category tag">Distribution</a>, <a href="https://lizards.opensuse.org/category/documentation/" rel="category tag">Documentation</a>, <a href="https://lizards.opensuse.org/category/distribution/factory/" rel="category tag">Factory</a>, <a href="https://lizards.opensuse.org/category/programming/" rel="category tag">Programming</a>, <a href="https://lizards.opensuse.org/category/systems-management/" rel="category tag">Systems Management</a>, <a href="https://lizards.opensuse.org/category/systems-management/yast/" rel="category tag">YaST</a> |   <a href="https://lizards.opensuse.org/2016/08/18/highlights-of-yast-development-sprint-23/#comments">2 Comments &#187;</a></p>
+        </div>
+
+      
+        <div class="post-11931 post type-post status-publish format-standard hentry category-miscellaneous category-programming tag-fedora tag-ipxe tag-mint tag-opensuse tag-ubuntu" id="post-11931">
+          <h2><a href="https://lizards.opensuse.org/2016/08/14/live-usb-improvements/" rel="bookmark" title="Permanent Link to Live USB improvements">Live USB improvements</a></h2>
+          <small>August 14th, 2016 by <a href="https://lizards.opensuse.org/author/cyberorg/" title="Posts by Jigish Gohil" rel="author">Jigish Gohil</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/08/14/live-usb-improvements/"
+                data-text="openSUSE News: Live USB improvements"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F08%2F14%2Flive-usb-improvements%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <p>Tools to create multi distribution bootable USB stick got couple of new improvements and features.</p>
+<p><a href="https://software.opensuse.org/package/live-usb-gui">live-usb-gui</a> now offers choice of scripts to use, depending in your need you can either use <a href="https://software.opensuse.org/package/live-fat-stick">live-fat-stick</a> with vfat partitioned stick or <a href="https://software.opensuse.org/package/live-grub-stick">live-grub-stick</a> script which works with any partition format supported by grub2 including vfat, must be used if you have iso bigger than 4G.</p>
+<p> <a href="https://lizards.opensuse.org/2016/08/14/live-usb-improvements/#more-11931" class="more-link">Read the rest of this entry &raquo;</a></p>
+          </div>
+
+          <p class="postmetadata">Tags: <a href="https://lizards.opensuse.org/tag/fedora/" rel="tag">Fedora</a>, <a href="https://lizards.opensuse.org/tag/ipxe/" rel="tag">iPXE</a>, <a href="https://lizards.opensuse.org/tag/mint/" rel="tag">Mint</a>, <a href="https://lizards.opensuse.org/tag/opensuse/" rel="tag">openSUSE</a>, <a href="https://lizards.opensuse.org/tag/ubuntu/" rel="tag">ubuntu</a><br /> Posted in <a href="https://lizards.opensuse.org/category/miscellaneous/" rel="category tag">Miscellaneous</a>, <a href="https://lizards.opensuse.org/category/programming/" rel="category tag">Programming</a> |   <span>Comments Off<span class="screen-reader-text"> on Live USB improvements</span></span></p>
+        </div>
+
+      
+        <div class="post-11920 post type-post status-publish format-standard hentry category-events category-marketing" id="post-11920">
+          <h2><a href="https://lizards.opensuse.org/2016/08/11/result-of-opensuse-asia-summit-2016-logo-contest/" rel="bookmark" title="Permanent Link to Result of openSUSE.Asia Summit 2016 Logo Contest">Result of openSUSE.Asia Summit 2016 Logo Contest</a></h2>
+          <small>August 11th, 2016 by <a href="https://lizards.opensuse.org/author/medwin/" title="Posts by M. Edwin Zakaria" rel="author">M. Edwin Zakaria</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/08/11/result-of-opensuse-asia-summit-2016-logo-contest/"
+                data-text="openSUSE News: Result of openSUSE.Asia Summit 2016 Logo Contest"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F08%2F11%2Fresult-of-opensuse-asia-summit-2016-logo-contest%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <p><a href="//lizards.opensuse.org/wp-content/uploads/2016/08/opensuse_asia_summit_2016_logo_winner.png"><img class="alignleft size-full wp-image-11921" src="//lizards.opensuse.org/wp-content/uploads/2016/08/opensuse_asia_summit_2016_logo_winner.png" alt="opensuse_asia_summit_2016_logo_winner" width="600" height="200" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/08/opensuse_asia_summit_2016_logo_winner.png 600w, https://lizards.opensuse.org/wp-content/uploads/2016/08/opensuse_asia_summit_2016_logo_winner-300x100.png 300w" sizes="(max-width: 600px) 100vw, 600px" /></a></p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<p>We are happy to announce that Ramadoni Ashudi design from Indonesia is selected as official logo for <a href="https://events.opensuse.org/conference/summitasia16">openSUSE.Asia Summit 2016</a> in Yogyakarta, Indonesia. As the winner Ramadoni Ashudi will receive a &#8220;magic box&#8221; from the committee.<br />
+Ramadoni Ashudi submit two designs and his design-2 selected by 28 voters. His design depicts his version of Tugu Yogyakarta, a monument built by Sultan Hamengkubuwono I, the first King of Yogyakarta in 1755.<br />
+Ana Maria Martinez from Spain also submit her version of Tugu Yogyakarta and selected by 17 voters on the 2nd place.<br />
+On the 3rd place, Shawhong Ser from Thailand submit a design that showing Arjuna character from Wayang Kulit, a traditional Javanese shadow puppet. Arjuna is the 3rd Pandava Brothers from Mahabharata. It is selected by 9 voters.</p>
+<p>Total of voters = 65<br />
+Ramadoni Ashudi-2 = 28<br />
+Ana Maria Martinez = 17<br />
+Shawhong Ser =  9<br />
+Aris Winardi =  4<br />
+Ramadoni Ashudi-1 =  4<br />
+Kukuh Syafaat =  3<br />
+Danang Aji Bimantoro-1 =  0<br />
+Danang Aji Bimantoro-2 =  0</p>
+<p>The complete result can be seen on the <a href="http://asiasummit16.opensuse.id/activity/4">contest web page</a></p>
+<p>Congratulation to Ramadoni, and many thanks and appreciation to Ana, Aris, Danang, Kukuh, Shawhong  for your participation in this contest.</p>
+<p>Have fun.</p>
+          </div>
+
+          <p class="postmetadata"> Posted in <a href="https://lizards.opensuse.org/category/events/" rel="category tag">Events</a>, <a href="https://lizards.opensuse.org/category/marketing/" rel="category tag">Marketing</a> |   <span>Comments Off<span class="screen-reader-text"> on Result of openSUSE.Asia Summit 2016 Logo Contest</span></span></p>
+        </div>
+
+      
+        <div class="post-11893 post type-post status-publish format-standard hentry category-distribution category-factory category-programming category-systems-management category-yast" id="post-11893">
+          <h2><a href="https://lizards.opensuse.org/2016/07/27/highlights-of-yast-development-sprint-22/" rel="bookmark" title="Permanent Link to Highlights of YaST development sprint 22">Highlights of YaST development sprint 22</a></h2>
+          <small>July 27th, 2016 by <a href="https://lizards.opensuse.org/author/yast-team/" title="Posts by Yast Team" rel="author">Yast Team</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/07/27/highlights-of-yast-development-sprint-22/"
+                data-text="openSUSE News: Highlights of YaST development sprint 22"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F07%2F27%2Fhighlights-of-yast-development-sprint-22%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <p><a href="https://events.opensuse.org/conference/oSC16">openSUSE Conference&#8217;16</a>, <a href="https://hackweek.suse.com">Hackweek 14</a> and the various SUSE internal workshops are over. So it&#8217;s time for the YaST team to go back to usual three-weeks-long development sprints&#8230; and with new sprints come new public reports!  </p>
+<p>With Leap 42.2 in Alpha phase and SLE12-SP2 in Beta phase our focus is on bugs fixing, so we don&#8217;t have as much fancy stuff to show in this report. Still, here you are some bits you could find interesting.</p>
+<h3>Installer memory consumption reduced</h3>
+<p>For our SLE customers we promise installations on machines with as little as 512MB of RAM. For Tumbleweed, 1GB is required &#8211; so the situation is more relaxed there.</p>
+<p>But look at the total size of filesystem images that must be kept in memory during installation: 176MB for SLE12 (Tumbleweed: 224MB). This is leaving not much room to run programs.</p>
+<p>The size has grown considerably over time, and we had to look for places to save space. We came up with some major areas for improvement.</p>
+<p>The initrd and the installation system (the file system image containing the installer) share many files (mainly libraries). By removing any overlap, we were able to reduce the image size by 17MB for SLE12 (Tumbleweed: 30MB).</p>
+<p>After the package installation starts, kernel modules and some raw libzypp cache data are no longer needed. By deleting zypp data we save another 3MB and kernel modules occupy even 29MB in SLE12 (Tumbleweed: 50MB). But we do this only on systems with less than 1GB memory.</p>
+<p>So, compared to the available 512MB, these savings are quite substantial and will hopefully keep us going for a while&#8230;</p>
+<h3>Storage reimplementation: another step to an installable system</h3>
+<p>It&#8217;s time for our reimplementation of the storage layer to prove it can do the real work. Thus, we have integrated the new code in a set of <a href="http://download.opensuse.org/repositories/YaST:/storage-ng/images/iso/">modified Tumbleweed ISO images</a> automatically generated in OBS. They cannot still be used to install a system, but the installer is already able to boot and reach the language selection screen (the first milestone we were aiming for).</p>
+<p>We already had code that works in a simulated test environment (unit tests) and now we have a way to use that code in a real installer. Stay tuned for exciting news!</p>
+<h3>Make many extensions fit on the screen properly</h3>
+<p>For SUSE Linux Enterprise we offer so many optional modules that their listing did not fit on lower resolution screens. Below you can see how the screen looked before the fix &#8211; checkbox widgets and their labels do not fit so their bottoms are cropped.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/07/bcropped.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/07/bcropped-300x225.png" alt="Old interface with cropped extensions" width="300" height="225" class="aligncenter size-medium wp-image-11895" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/07/bcropped-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bcropped-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bcropped.png 800w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>We have to make sure YaST works across different interfaces, including text-based ncurses. That limits the set of widgets we can use when designing interfaces, so finding a solution to that kind of problems is not always easy. We also took the opportunity to add a filter for beta extensions, as you can see in the following screenshot.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/07/bfiltered.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/07/bfiltered-300x225.png" alt="The beta extensions filter in action" width="300" height="225" class="aligncenter size-medium wp-image-11896" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/07/bfiltered-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bfiltered-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bfiltered.png 800w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>And finally you can see how it looks like with all the extensions, including beta ones. Instead of cropping elements we now have a scroll-bar in the right.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/07/bmodules.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/07/bmodules-300x225.png" alt="The new extensions UI in all its glory" width="300" height="225" class="aligncenter size-medium wp-image-11897" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/07/bmodules-300x225.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bmodules-768x576.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bmodules.png 800w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Storage reimplementation: LVM unit testing</h3>
+<p>The next step in the storage layer reimplementation is adding support for LVM, since right now only regular partitions are supported. We always write a lot of unit tests to make sure the different pieces work in isolation before integrating everything together into the installer. During this sprint we created all the infrastructure for testing LVM at such level. Armed with that, we can start writing reliable code to handle LVM (something we have already started to do).</p>
+<h3>Improved patterns handling for system roles</h3>
+<p>We recently introduced the concept of system roles during installation. The chosen role affects the selection of package patterns. But we realized that the roles were not completely overriding the default selection of packages. Before the fix introduced in this sprint, desktop related patterns were included  for a <a href="https://github.com/yast/yast-installation/wiki/System-Role">KVM server role</a> and, thus, the systemd target was graphical.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/07/bbadrole.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/07/bbadrole-300x234.png" alt="The KVM Server role before the fix" width="300" height="234" class="aligncenter size-medium wp-image-11902" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/07/bbadrole-300x234.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bbadrole-768x599.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bbadrole.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<p>Now, only the 3 patterns explicitly intended for the KVM role are selected, with no desktop related patterns. Accordingly, the system boots to text mode.</p>
+<p><a href="//lizards.opensuse.org/wp-content/uploads/2016/07/bgoodrole.png"><img src="//lizards.opensuse.org/wp-content/uploads/2016/07/bgoodrole-300x234.png" alt="Fixed KVM Server role" width="300" height="234" class="aligncenter size-medium wp-image-11903" srcset="https://lizards.opensuse.org/wp-content/uploads/2016/07/bgoodrole-300x234.png 300w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bgoodrole-768x599.png 768w, https://lizards.opensuse.org/wp-content/uploads/2016/07/bgoodrole.png 1024w" sizes="(max-width: 300px) 100vw, 300px" /></a></p>
+<h3>Storage reimplementation: the future of booting</h3>
+<p>We have explained in several previous posts how we are collaborating with Grub and hardware architecture experts to make sure the new storage layer makes always sensible partitioning proposals. For that purpose <a href="http://rspec.info/">RSpec</a> has proven to be an excellent tool. It does not only allow us to have full unit test coverage or our code, but also the generated output has become the perfect base to discuss the expected behavior of the system in every possible scenario.</p>
+<p>During this sprint, we spent quite some time together with SUSE&#8217;s Grub genius Michael Chang defining the best possible partitioning schema in x86 architectures. Once we had a human-readable and non-ambiguous specification, we modified our code to make sure the associated RSpec tests generated exactly the <a href="https://github.com/yast/yast-storage-ng/blob/master/doc/boot-requirements.md">same specification</a> as output. This way we make sure that our code works and that it fits 100% the experts expectations.</p>
+<p>Kudos to Michael for his infinite patience with our questions and for coming up with an innovative way of using Grub2 that will allow us to boot in many tricky scenarios, eliminating the need of introducing a separate <code>/boot</code> in almost all cases.</p>
+<h3>Conclusion</h3>
+<p>As said, most of the sprint was invested in chasing bugs&#8230; and we don&#8217;t expect next sprint to be different in that regard. Even though, we hope this post to contain enough new stuff to keep you entertained and informed about what is going on in the YaST trenches.</p>
+<p>See you in three weeks!</p>
+          </div>
+
+          <p class="postmetadata"> Posted in <a href="https://lizards.opensuse.org/category/distribution/" rel="category tag">Distribution</a>, <a href="https://lizards.opensuse.org/category/distribution/factory/" rel="category tag">Factory</a>, <a href="https://lizards.opensuse.org/category/programming/" rel="category tag">Programming</a>, <a href="https://lizards.opensuse.org/category/systems-management/" rel="category tag">Systems Management</a>, <a href="https://lizards.opensuse.org/category/systems-management/yast/" rel="category tag">YaST</a> |   <a href="https://lizards.opensuse.org/2016/07/27/highlights-of-yast-development-sprint-22/#comments">1 Comment &#187;</a></p>
+        </div>
+
+      
+        <div class="post-11890 post type-post status-publish format-standard hentry category-miscellaneous category-server" id="post-11890">
+          <h2><a href="https://lizards.opensuse.org/2016/07/21/tally-erp-9-on-linux/" rel="bookmark" title="Permanent Link to Tally ERP 9 on Linux">Tally ERP 9 on Linux</a></h2>
+          <small>July 21st, 2016 by <a href="https://lizards.opensuse.org/author/cyberorg/" title="Posts by Jigish Gohil" rel="author">Jigish Gohil</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/07/21/tally-erp-9-on-linux/"
+                data-text="openSUSE News: Tally ERP 9 on Linux"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F07%2F21%2Ftally-erp-9-on-linux%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <p>Recently we implemented <a href="http://www.tallysolutions.com/products/tallyerp9/">Tally ERP 9</a> solution for <a href="http://anticopumps.co.in/">Antico Pumps</a>. That itself is not interesting, the interesting part is they are using <a href="http://ltsp.org/">LTSP</a> Fat client system on <a href="https://www.opensuse.org/">openSUSE</a>. They have only one server from which all their client computers boot over the network, the clients do not have hard disk, client OS with all softwares they need including wine(Tally is Windows only software), as well as users&#8217; data resides on the server. Once the client boots all the local resources are used so single low power server can be used to serve many clients.</p>
+<p>Tally multiuser is served from a Samba share  on a NAS device, Tally folder is copied to samba share and path to Tally Data is changed so that it points there. Everything they need including printing and export(CSV) works from all clients. Same way Tally can be run on standalone computers. Neither Tally, Wine or openSUSE are modified for getting it working as it would under Windows environment.</p>
+          </div>
+
+          <p class="postmetadata"> Posted in <a href="https://lizards.opensuse.org/category/miscellaneous/" rel="category tag">Miscellaneous</a>, <a href="https://lizards.opensuse.org/category/server/" rel="category tag">Server</a> |   <span>Comments Off<span class="screen-reader-text"> on Tally ERP 9 on Linux</span></span></p>
+        </div>
+
+      
+        <div class="post-11887 post type-post status-publish format-standard hentry category-distribution" id="post-11887">
+          <h2><a href="https://lizards.opensuse.org/2016/07/11/zypper-patch-uninstall-rollback/" rel="bookmark" title="Permanent Link to Uninstall a patch using zypper">Uninstall a patch using zypper</a></h2>
+          <small>July 11th, 2016 by <a href="https://lizards.opensuse.org/author/andreasstieger/" title="Posts by AndreasStieger" rel="author">AndreasStieger</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/07/11/zypper-patch-uninstall-rollback/"
+                data-text="openSUSE News: Uninstall a patch using zypper"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F07%2F11%2Fzypper-patch-uninstall-rollback%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <p>Maintenance and security updates for the stable openSUSE Leap releases are automatically tested using OpenQA, and also receive community testing prior to release. In addition, many updates to openSUSE Leap are inherited from <a href="https://www.suse.com/">SUSE&#8217;s enterprise products</a>, where they already receive thorough review, and automated as well as manual testing.</p>
+<p>Should anything go wrong, here is how to &#8220;uninstall&#8221; an online update using <code>zypper</code>.</p>
+<p><code>zypper in --oldpackage ` \<br />
+zypper info -t patch --conflicts openSUSE-2016-XXX | \<br />
+grep " &lt; &quot; | while read NAME C VERSION; do \<br />
+    rpm --quiet -q --queryformat &quot;%{name}\n&quot; $NAME &amp;&amp; echo &quot;${NAME}&lt;${VERSION}&quot;; \<br />
+done`</code></p>
+<p>Replace <code>openSUSE-2016-XXX</code> with the update in question. All involved packages are installed in a prior version. This, of course, is an alternative to using Btrfs snapshots. Note that the update will be offered again.</p>
+<p>If you want to help review proposed online updates, just check the &#8220;untested updates&#8221; repo in YaST or add one of the <a href="http://download.opensuse.org/update/leap/42.1-test/" target="_blank"><code>-test</code></a> repositories to receive updates early.</p>
+          </div>
+
+          <p class="postmetadata"> Posted in <a href="https://lizards.opensuse.org/category/distribution/" rel="category tag">Distribution</a> |   <span>Comments Off<span class="screen-reader-text"> on Uninstall a patch using zypper</span></span></p>
+        </div>
+
+      
+        <div class="post-11885 post type-post status-publish format-standard hentry category-derivative category-distribution category-education" id="post-11885">
+          <h2><a href="https://lizards.opensuse.org/2016/07/04/future-of-li-f-e-linux-for-education-distribution/" rel="bookmark" title="Permanent Link to Future of Li-f-e: Linux for Education distribution">Future of Li-f-e: Linux for Education distribution</a></h2>
+          <small>July 4th, 2016 by <a href="https://lizards.opensuse.org/author/cyberorg/" title="Posts by Jigish Gohil" rel="author">Jigish Gohil</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/07/04/future-of-li-f-e-linux-for-education-distribution/"
+                data-text="openSUSE News: Future of Li-f-e: Linux for Education distribution"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F07%2F04%2Ffuture-of-li-f-e-linux-for-education-distribution%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <p>We have come a long way since the first Li-f-e live media based on openSUSE was created, the <a href="https://en.opensuse.org/openSUSE:Education-Li-f-e" target="_blank">current release</a> is based on <a href="https://en.opensuse.org/Portal:42.1" target="_blank">openSUSE Leap 42.1</a>. <a href="https://news.opensuse.org/2015/05/27/indonesia-uses-linux-opensuse-for-pilot-project/" target="_blank">Deployments by Indonesia&#8217;s</a> education system is a shining example of <a href="https://en.opensuse.org/Education">openSUSE Education</a> project&#8217;s accomplishment.</p>
+<p>The openSUSE project has stopped producing live medias for Leap and also live-installer is dropped from live medias created for the Tumbleweed distribution. As Li-f-e is primarily a live distribution we would not be able to create any more medias without live-installer. So unless this situation changes we may not have Li-f-e based on Leap 42.2.</p>
+<p>In the meantime I&#8217;ve had a look at <a href="http://www.ubuntu.com/" target="_blank">Ubuntu</a> to create Li-f-e based on the latest LTS release of <a href="https://ubuntu-mate.org/" target="_blank">Ubuntu-Mate</a>, check it out <a href="https://sourceforge.net/projects/cyberorg-home/files/Li-f-e/" target="_blank">here</a>. Software selection available is kept identical to the Li-f-e based on openSUSE, however there is always a room for improvement, suggestions to enhance it are always welcome.</p>
+<p><iframe width="500" height="281" src="https://www.youtube.com/embed/KW0XHESvE9g?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
+          </div>
+
+          <p class="postmetadata"> Posted in <a href="https://lizards.opensuse.org/category/distribution/derivative/" rel="category tag">Derivative</a>, <a href="https://lizards.opensuse.org/category/distribution/" rel="category tag">Distribution</a>, <a href="https://lizards.opensuse.org/category/education/" rel="category tag">Education</a> |   <a href="https://lizards.opensuse.org/2016/07/04/future-of-li-f-e-linux-for-education-distribution/#comments">6 Comments &#187;</a></p>
+        </div>
+
+      
+        <div class="post-11878 post type-post status-publish format-standard hentry category-factory category-systems-management category-yast" id="post-11878">
+          <h2><a href="https://lizards.opensuse.org/2016/06/23/highlights-of-yast-development-sprint-21/" rel="bookmark" title="Permanent Link to Highlights of YaST development sprint 21">Highlights of YaST development sprint 21</a></h2>
+          <small>June 23rd, 2016 by <a href="https://lizards.opensuse.org/author/yast-team/" title="Posts by Yast Team" rel="author">Yast Team</a> </small>
+
+          <div class="share-links">
+            <div class="share-link">
+              <a href="http://twitter.com/share" class="twitter-share-button"
+                data-url="https://lizards.opensuse.org/2016/06/23/highlights-of-yast-development-sprint-21/"
+                data-text="openSUSE News: Highlights of YaST development sprint 21"
+                data-count="horizontal"
+                data-hashtags="openSUSE"
+                data-via="openSUSE">Tweet</a>
+            </div>
+            <div class="share-link">
+              <iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Flizards.opensuse.org%2F2016%2F06%2F23%2Fhighlights-of-yast-development-sprint-21%2F&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;colorscheme=light&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:100px; height:21px;" allowTransparency="true"></iframe>
+            </div>
+	    <div class="share-link">
+              <g:plusone size="medium"></g:plusone>
+            </div>
+            <div class="clear"></div>
+          </div>
+          
+          <div class="entry">
+            <h3 id="installation-video-mode">Installation Video Mode</h3>
+<p>If you need to make screenshots of the installation it is useful to influence their size. You could press <code>F3</code> in the boot menu and choose from a menu, but that is not well suited for scripts such as openQA.</p>
+<p>The installer now obeys an <a href="https://en.opensuse.org/SDB:Linuxrc#p_xvideo">option</a> from the boot command line: <code>xvideo</code>.</p>
+<pre><code>xvideo=[WIDTHxHEIGHT][,DPI]
+xvideo=1024x768
+xvideo=1024x768,100
+xvideo=,100</code></pre>
+<p><small>(Available in yast2-installation-3.1.195 + yast2-x11-3.1.5. <a href="https://bugzilla.suse.com/show_bug.cgi?id=974821">bsc#974821</a>)</small></p>
+<h3 id="how-to-install-with-a-self-signed-certificate">How to Install with a Self-Signed Certificate</h3>
+<p>You can now install from a repository served with HTTPS that has a self-signed certificate. Use a <a href="https://en.opensuse.org/SDB:Linuxrc#p_sslcerts"><code>ssl_certs=0</code> boot option</a>.</p>
+<p><small>(Available in yast2-packager-3.1.104. <a href="https://bugzilla.suse.com/show_bug.cgi?id=982727">bsc#982727</a>)</small></p>
+<h3 id="installation-local-smt-servers-are-pre-filled">Installation: Local SMT Servers are Pre-filled</h3>
+<p>Last sprint (<a href="https://lizards.opensuse.org/2016/06/07/highlights-of-yast-development-sprint-20/">S#20</a>) we improved the registration UI. Now we&#8217;ve made one more improvement: pre-filling the <em>Register System via local SMT Server</em> field.</p>
+<p>Before, the widget was a single text field and a little helpful <code>smt.example.com</code> was always shown (no matter what your actual domain was). <img src="https://cloud.githubusercontent.com/assets/102056/16152080/50519e9e-34a0-11e6-93f1-6402aa1be0d4.png" alt="local-smt-server-1-before" /></p>
+<p>Now, if your local <a href="https://www.suse.com/documentation/smt11/">SMT</a> servers are advertised via <a href="https://en.wikipedia.org/wiki/Service_Location_Protocol">SLP</a> they will be offered as choices. (Here <code>acme.com</code> stands for your domain) <img src="https://cloud.githubusercontent.com/assets/102056/16152092/58652218-34a0-11e6-9754-a4181ec2ea20.png" alt="local-smt-server-2-after" /></p>
+<p><small>(Available in yast2-registration-3.1.176. <a href="https://bugzilla.suse.com/show_bug.cgi?id=981633">bsc#981633</a>.)</small></p>
+<h3 id="new-storage-iso">New Storage: ISO</h3>
+<p>We have started building an <a href="http://download.opensuse.org/repositories/YaST:/storage-ng/images">installation ISO image</a> with the <a href="https://build.opensuse.org/project/show/YaST:storage-ng">new storage library</a>. The first build contains all the pieces but they don&#8217;t work together yet.</p>
+<h3 id="new-storage-boot-scenarios">New Storage: Boot Scenarios</h3>
+<p>We have documented the <a href="https://github.com/yast/yast-storage-ng/blob/master/doc/boot-requirements.md">supported scenarios</a> regarding booting in the new storage layer.</p>
+<p><small>(Tooling note: We made this with a <a href="https://github.com/yast/yast-storage-ng/blob/master/src/tools/md_formatter.rb">Markdown formatter for RSpec</a> invoked <a href="https://github.com/yast/yast-storage-ng/blob/master/rakelib/doc_bootspecs.rake">like this</a>.)</small></p>
+<h3 id="network-settings-are-less-eager-to-restart">Network Settings are Less Eager to Restart</h3>
+<p>If you opened Network Settings to review something, made no changes, and closed the dialog with OK, the network would be restarted. That may be undesirable if you have an Important Application running. We originally thought that everyone would close the dialog with Cancel, but we were proven wrong.</p>
+<p>Now the module properly checks whether you have made changes to the settings, and omits the restart if appropriate.</p>
+<p><small>(Available in yast2-network-3.1.155. <a href="https://fate.suse.com/318787">FATE#318787</a>)</small></p>
+<h3 id="network-in-autoyast">Network in AutoYaST</h3>
+<p>Due to a problem in the AutoYaST version shipped with SLE 12 SP1 and openSUSE Leap 42.1, the network configuration used during the first stage was always copied to the installed system regardless the value of <code>keep_install_network</code>.</p>
+<p>Upcoming SLE 12 SP2 and Leap 42.2 behaves as expected and <code>keep_install_network</code> will be set to <code>true</code> by default.</p>
+<p><small>(Available in yast2-network-3.1.157 + autoyast2-3.1.133. Fixes <a href="https://bugzilla.suse.com/show_bug.cgi?id=984146">bsc#984146</a>.)</small></p>
+          </div>
+
+          <p class="postmetadata"> Posted in <a href="https://lizards.opensuse.org/category/distribution/factory/" rel="category tag">Factory</a>, <a href="https://lizards.opensuse.org/category/systems-management/" rel="category tag">Systems Management</a>, <a href="https://lizards.opensuse.org/category/systems-management/yast/" rel="category tag">YaST</a> |   <span>Comments Off<span class="screen-reader-text"> on Highlights of YaST development sprint 21</span></span></p>
+        </div>
+
+      
+      <div class="navigation page-navigation">
+        <div class="alignleft"><a href="https://lizards.opensuse.org/page/3/" >&laquo; Older Entries</a></div>
+        <div class="alignright"><a href="https://lizards.opensuse.org/" >Newer Entries &raquo;</a></div>
+      </div>
+
+    
+  </div>
+
+  
+<div class="grid_4 omega aside">
+  <!-- <div class="box box-shadow"> -->
+    <ul>
+      <li id="text-3" class="widget box box-shadow widget_text"><h3 class="box-subheader">Advertisement</h3>			<div class="textwidget"><center><a href="http://counter.opensuse.org/link/" alt="counter" title="Get it!"><img src="//counter.opensuse.org/small"></a></center></div>
+		</li><li id="tag_cloud-3" class="widget box box-shadow widget_tag_cloud"><h3 class="box-subheader">Tags</h3><div class="tagcloud"><a href='https://lizards.opensuse.org/tag/11-3/' class='tag-link-380 tag-link-position-1' title='15 topics' style='font-size: 12.579439252336pt;'>11.3</a>
+<a href='https://lizards.opensuse.org/tag/11-4/' class='tag-link-414 tag-link-position-2' title='47 topics' style='font-size: 18.859813084112pt;'>11.4</a>
+<a href='https://lizards.opensuse.org/tag/12-1/' class='tag-link-482 tag-link-position-3' title='34 topics' style='font-size: 17.028037383178pt;'>12.1</a>
+<a href='https://lizards.opensuse.org/tag/12-2/' class='tag-link-549 tag-link-position-4' title='25 topics' style='font-size: 15.327102803738pt;'>12.2</a>
+<a href='https://lizards.opensuse.org/tag/12-3/' class='tag-link-559 tag-link-position-5' title='22 topics' style='font-size: 14.672897196262pt;'>12.3</a>
+<a href='https://lizards.opensuse.org/tag/13-1/' class='tag-link-570 tag-link-position-6' title='20 topics' style='font-size: 14.14953271028pt;'>13.1</a>
+<a href='https://lizards.opensuse.org/tag/13-2/' class='tag-link-632 tag-link-position-7' title='10 topics' style='font-size: 10.485981308411pt;'>13.2</a>
+<a href='https://lizards.opensuse.org/tag/amd/' class='tag-link-434 tag-link-position-8' title='47 topics' style='font-size: 18.859813084112pt;'>amd</a>
+<a href='https://lizards.opensuse.org/tag/arm/' class='tag-link-279 tag-link-position-9' title='17 topics' style='font-size: 13.364485981308pt;'>ARM</a>
+<a href='https://lizards.opensuse.org/tag/ati/' class='tag-link-384 tag-link-position-10' title='44 topics' style='font-size: 18.467289719626pt;'>ATI</a>
+<a href='https://lizards.opensuse.org/tag/beta/' class='tag-link-343 tag-link-position-11' title='8 topics' style='font-size: 9.3084112149533pt;'>Beta</a>
+<a href='https://lizards.opensuse.org/tag/build-service/' class='tag-link-728 tag-link-position-12' title='13 topics' style='font-size: 11.92523364486pt;'>Build Service</a>
+<a href='https://lizards.opensuse.org/tag/buildservice/' class='tag-link-45 tag-link-position-13' title='6 topics' style='font-size: 8pt;'>buildservice</a>
+<a href='https://lizards.opensuse.org/tag/c-language/' class='tag-link-575 tag-link-position-14' title='8 topics' style='font-size: 9.3084112149533pt;'>C-Language</a>
+<a href='https://lizards.opensuse.org/tag/cloud/' class='tag-link-584 tag-link-position-15' title='9 topics' style='font-size: 9.9626168224299pt;'>cloud</a>
+<a href='https://lizards.opensuse.org/tag/collaboration/' class='tag-link-59 tag-link-position-16' title='7 topics' style='font-size: 8.6542056074766pt;'>Collaboration</a>
+<a href='https://lizards.opensuse.org/tag/community/' class='tag-link-173 tag-link-position-17' title='30 topics' style='font-size: 16.373831775701pt;'>Community</a>
+<a href='https://lizards.opensuse.org/tag/conference/' class='tag-link-355 tag-link-position-18' title='10 topics' style='font-size: 10.485981308411pt;'>conference</a>
+<a href='https://lizards.opensuse.org/tag/education/' class='tag-link-744 tag-link-position-19' title='18 topics' style='font-size: 13.626168224299pt;'>Education</a>
+<a href='https://lizards.opensuse.org/tag/event/' class='tag-link-37 tag-link-position-20' title='7 topics' style='font-size: 8.6542056074766pt;'>event</a>
+<a href='https://lizards.opensuse.org/tag/events/' class='tag-link-731 tag-link-position-21' title='9 topics' style='font-size: 9.9626168224299pt;'>Events</a>
+<a href='https://lizards.opensuse.org/tag/factory/' class='tag-link-745 tag-link-position-22' title='14 topics' style='font-size: 12.317757009346pt;'>Factory</a>
+<a href='https://lizards.opensuse.org/tag/fglrx/' class='tag-link-385 tag-link-position-23' title='41 topics' style='font-size: 18.07476635514pt;'>fglrx</a>
+<a href='https://lizards.opensuse.org/tag/fun/' class='tag-link-200 tag-link-position-24' title='14 topics' style='font-size: 12.317757009346pt;'>fun</a>
+<a href='https://lizards.opensuse.org/tag/gnome/' class='tag-link-723 tag-link-position-25' title='13 topics' style='font-size: 11.92523364486pt;'>GNOME</a>
+<a href='https://lizards.opensuse.org/tag/gsoc/' class='tag-link-261 tag-link-position-26' title='11 topics' style='font-size: 11.009345794393pt;'>gsoc</a>
+<a href='https://lizards.opensuse.org/tag/hackweek/' class='tag-link-741 tag-link-position-27' title='8 topics' style='font-size: 9.3084112149533pt;'>Hackweek</a>
+<a href='https://lizards.opensuse.org/tag/kde/' class='tag-link-722 tag-link-position-28' title='25 topics' style='font-size: 15.327102803738pt;'>KDE</a>
+<a href='https://lizards.opensuse.org/tag/kernel/' class='tag-link-727 tag-link-position-29' title='48 topics' style='font-size: 18.990654205607pt;'>Kernel</a>
+<a href='https://lizards.opensuse.org/tag/kraft/' class='tag-link-247 tag-link-position-30' title='8 topics' style='font-size: 9.3084112149533pt;'>Kraft</a>
+<a href='https://lizards.opensuse.org/tag/linux/' class='tag-link-362 tag-link-position-31' title='13 topics' style='font-size: 11.92523364486pt;'>Linux</a>
+<a href='https://lizards.opensuse.org/tag/lxde/' class='tag-link-287 tag-link-position-32' title='12 topics' style='font-size: 11.401869158879pt;'>LXDE</a>
+<a href='https://lizards.opensuse.org/tag/obs/' class='tag-link-218 tag-link-position-33' title='9 topics' style='font-size: 9.9626168224299pt;'>obs</a>
+<a href='https://lizards.opensuse.org/tag/opensuse/' class='tag-link-38 tag-link-position-34' title='82 topics' style='font-size: 22pt;'>openSUSE</a>
+<a href='https://lizards.opensuse.org/tag/opensuse-id/' class='tag-link-50 tag-link-position-35' title='6 topics' style='font-size: 8pt;'>openSUSE-ID</a>
+<a href='https://lizards.opensuse.org/tag/package/' class='tag-link-58 tag-link-position-36' title='7 topics' style='font-size: 8.6542056074766pt;'>Package</a>
+<a href='https://lizards.opensuse.org/tag/postgresql/' class='tag-link-367 tag-link-position-37' title='7 topics' style='font-size: 8.6542056074766pt;'>PostgreSQL</a>
+<a href='https://lizards.opensuse.org/tag/radeon/' class='tag-link-464 tag-link-position-38' title='10 topics' style='font-size: 10.485981308411pt;'>radeon</a>
+<a href='https://lizards.opensuse.org/tag/raspberry/' class='tag-link-565 tag-link-position-39' title='11 topics' style='font-size: 11.009345794393pt;'>raspberry</a>
+<a href='https://lizards.opensuse.org/tag/raspberry-pi/' class='tag-link-679 tag-link-position-40' title='8 topics' style='font-size: 9.3084112149533pt;'>Raspberry Pi</a>
+<a href='https://lizards.opensuse.org/tag/rpm/' class='tag-link-269 tag-link-position-41' title='13 topics' style='font-size: 11.92523364486pt;'>rpm</a>
+<a href='https://lizards.opensuse.org/tag/tumbleweed/' class='tag-link-616 tag-link-position-42' title='13 topics' style='font-size: 11.92523364486pt;'>Tumbleweed</a>
+<a href='https://lizards.opensuse.org/tag/xml/' class='tag-link-69 tag-link-position-43' title='8 topics' style='font-size: 9.3084112149533pt;'>XML</a>
+<a href='https://lizards.opensuse.org/tag/xorg-2/' class='tag-link-444 tag-link-position-44' title='30 topics' style='font-size: 16.373831775701pt;'>xorg</a>
+<a href='https://lizards.opensuse.org/tag/yast/' class='tag-link-725 tag-link-position-45' title='13 topics' style='font-size: 11.92523364486pt;'>YaST</a></div>
+</li>		<li id="authors-2" class="widget box box-shadow widget_authors">			<h3 class="box-subheader">Lizards</h3>			<ul><li><img alt='' src='https://secure.gravatar.com/avatar/3708092c81f7bcbf444068a02cc7e566?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/3708092c81f7bcbf444068a02cc7e566?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/aaronluna75/" title="Posts by Aaron Luna">Aaron Luna</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/665cc4ce5b7e7735c418a6bf857227d0?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/665cc4ce5b7e7735c418a6bf857227d0?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/adriansuse/" title="Posts by Adrian Schröter">Adrian Schröter</a> (12)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/6b405d89e8a498ae6a52f60246bb1cb3?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/6b405d89e8a498ae6a52f60246bb1cb3?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/dj_ubun_1/" title="Posts by Agustin Chavarria">Agustin Chavarria</a> (6)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/de70b01367308284c7fffa046b2faf16?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/de70b01367308284c7fffa046b2faf16?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/cabelo/" title="Posts by Alessandro de Oliveira Faria">Alessandro de Oliveira Faria</a> (10)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9c20c306e84e644f7437fbea954c56c0?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9c20c306e84e644f7437fbea954c56c0?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/alexbariv/" title="Posts by Alex Barrios">Alex Barrios</a> (12)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/cbae0a6b288a060e2f4f83897dbc62f5?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/cbae0a6b288a060e2f4f83897dbc62f5?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/alexander_naumov/" title="Posts by Alexander Naumov">Alexander Naumov</a> (10)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/c04c73736241252ce1748dcb0b4af496?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/c04c73736241252ce1748dcb0b4af496?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/aorlovskyy/" title="Posts by Alexander Orlovskyy">Alexander Orlovskyy</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/1091099af3cd8b684eaba8124c063c45?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/1091099af3cd8b684eaba8124c063c45?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/ealin/" title="Posts by Alin M Elena">Alin M Elena</a> (5)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/12b8b4d0de48863920df21b576b12e89?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/12b8b4d0de48863920df21b576b12e89?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/anubisg1/" title="Posts by Andrea Florio">Andrea Florio</a> (27)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/f15a600d57849d9dc3e0d23539212583?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/f15a600d57849d9dc3e0d23539212583?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/a_jaeger/" title="Posts by Andreas Jaeger">Andreas Jaeger</a> (70)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/60bbc6f441037a434cad33eca68f2bd8?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/60bbc6f441037a434cad33eca68f2bd8?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/andreasstieger/" title="Posts by AndreasStieger">Andreas Stieger</a> (9)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/0c18cf5651bb5ad3c8c6cd10467be536?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/0c18cf5651bb5ad3c8c6cd10467be536?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/funkypenguin/" title="Posts by Andrew Wafaa">Andrew Wafaa</a> (31)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/17c5d6b91957787db64c3d65c9a9b234?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/17c5d6b91957787db64c3d65c9a9b234?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/aschnell/" title="Posts by Arvin Schnell">Arvin Schnell</a> (9)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/33b7ed7d1a68409cffbb4fce216c410c?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/33b7ed7d1a68409cffbb4fce216c410c?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/badshah400/" title="Posts by badshah400">Atri Bhattacharya</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/c57258b3faac137a43ddcc63deb22517?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/c57258b3faac137a43ddcc63deb22517?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/bmwiedemann/" title="Posts by bmwiedemann">Bernhard Wiedemann</a> (22)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/3081cb247a705dcb3c912cce12ccb986?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/3081cb247a705dcb3c912cce12ccb986?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/kurniawan-007/" title="Posts by Bonnie Kurniawan">Bonnie Kurniawan</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/482b6c0369f4709de8faa6843cd6b347?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/482b6c0369f4709de8faa6843cd6b347?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/bruno_friedmann/" title="Posts by Bruno Friedmann">Bruno Friedmann</a> (97)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/83f40d98130b1fd3a741b9f01b2f76b1?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/83f40d98130b1fd3a741b9f01b2f76b1?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/calumma/" title="Posts by calumma">Calumma Brevicorne</a> (29)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/5fb81daf243732ab579b45f3bb261041?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/5fb81daf243732ab579b45f3bb261041?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/caf4926/" title="Posts by Carl Fletcher">Carl Fletcher</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/5f12ccab9a5217492279b93dc338f8a3?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/5f12ccab9a5217492279b93dc338f8a3?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/hobbsc/" title="Posts by Christopher Hobbs">Christopher Hobbs</a> (17)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/7a36aa34f42120643cfd761f32ddceca?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/7a36aa34f42120643cfd761f32ddceca?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/babelworx/" title="Posts by Ciaran Farrell">Ciaran Farrell</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/e4e8389140088920840a562d3ea05469?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/e4e8389140088920840a562d3ea05469?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/coolo/" title="Posts by coolo">Stephan Kulow</a> (17)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9195974d6d0f1b8fd7b702dd81618406?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9195974d6d0f1b8fd7b702dd81618406?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/ganglia/" title="Posts by Craig Gardner">craig gardner</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/50a30bb897b32f99e982ea3b2088fa6a?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/50a30bb897b32f99e982ea3b2088fa6a?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/cyberiad/" title="Posts by cyberiad">Stephan Barth</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/ced20b885a7272cd73a486554652cefc?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/ced20b885a7272cd73a486554652cefc?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/digitaltomm/" title="Posts by digitaltomm">Tom Schmidt</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/0d85a5dc9f7e029d5817cd21fe7b6505?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/0d85a5dc9f7e029d5817cd21fe7b6505?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/k0da/" title="Posts by Dinar Valeev">Dinar Valeev</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/c13f6726c52ab070fa80fa59a08f5c7c?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/c13f6726c52ab070fa80fa59a08f5c7c?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/dirkmueller/" title="Posts by Dirk Müller">Dirk Müller</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/cf1abc404bab4754fa7a15627fe1a3e0?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/cf1abc404bab4754fa7a15627fe1a3e0?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/dmitry_serpokryl/" title="Posts by Dmitry Serpokryl">Dmitry Serpokryl</a> (7)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/407c50e010f7ee5d7273ed7d28a82ebf?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/407c50e010f7ee5d7273ed7d28a82ebf?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/dsterba/" title="Posts by dsterba">David Sterba</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/d7d214befb27d85b5e7f8d2d8ede8b45?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/d7d214befb27d85b5e7f8d2d8ede8b45?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/diamond_gr/" title="Posts by Efstathios Iosifidis">Efstathios Iosifidis</a> (22)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/ba9a8bde051ca69ad1d24b565d907482?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/ba9a8bde051ca69ad1d24b565d907482?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/fabiomux/" title="Posts by FabioMux">Fabio Mucciante</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/3feb252147c4c69e4de152006c0b3fce?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/3feb252147c4c69e4de152006c0b3fce?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/flucifredi/" title="Posts by Federico Lucifredi">Federico Lucifredi</a> (9)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/25bbc96d9c53647354cb724e744b2222?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/25bbc96d9c53647354cb724e744b2222?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/gregfreemyer/" title="Posts by Greg Freemyer">Greg Freemyer</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/31e251b53e7c41d1fd130ae3809c0092?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/31e251b53e7c41d1fd130ae3809c0092?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/holgisms/" title="Posts by Holgi">Holger Sickenberg</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/26505b78e4a5b312c389b578093f6fa6?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/26505b78e4a5b312c389b578093f6fa6?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/wiederda/" title="Posts by Hubert Mantel">Hubert Mantel</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/a04dfb1adae5db8df437ae769c263ca7?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/a04dfb1adae5db8df437ae769c263ca7?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/ansus/" title="Posts by Ilya Chernykh">Ilya Chernykh</a> (5)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/ae3a82716dc7b3f4b8ef9b7508d80c5e?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/ae3a82716dc7b3f4b8ef9b7508d80c5e?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/namtrac/" title="Posts by Ismail Donmez">Ismail Donmez</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/cafe9fb55db0cc3f1f68a327ba1d9eee?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/cafe9fb55db0cc3f1f68a327ba1d9eee?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/jdsn/" title="Posts by J. Daniel Schmidt">J. Daniel Schmidt</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/d79616993dab466bee3456e8ac46bfee?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/d79616993dab466bee3456e8ac46bfee?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/jasujt/" title="Posts by James Tremblay">James Tremblay</a> (7)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/c6ce61b8d0a3569ef85184dda1570590?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/c6ce61b8d0a3569ef85184dda1570590?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/janblunck/" title="Posts by Jan Blunck">Jan Blunck</a> (4)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/175c7154a5704e340a373531fa9d342f?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/175c7154a5704e340a373531fa9d342f?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/jloeser/" title="Posts by Jan Loeser">Jan Loeser</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9eb4acd92a9546fbb0b0a269e08cf810?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9eb4acd92a9546fbb0b0a269e08cf810?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/jan-portugal/" title="Posts by Jan Madsen">Jan Madsen</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9dbacbc8f5a66d9a6f99c828312bf910?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9dbacbc8f5a66d9a6f99c828312bf910?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/helcaraxe/" title="Posts by Jan-Christoph Bornschlegel">Jan-Christoph Bornschlegel</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/a73d94bc71ab9211ed8a31e3ede4fbfe?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/a73d94bc71ab9211ed8a31e3ede4fbfe?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/dl9pf/" title="Posts by Jan-Simon Möller">Jan-Simon Möller</a> (20)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/8b42838e6dccf7eb90a8ba362e7de858?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/8b42838e6dccf7eb90a8ba362e7de858?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/javierllorente/" title="Posts by Javier Llorente">Javier Llorente</a> (12)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/8b6e7e1e33323b1499e01776ea5ce307?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/8b6e7e1e33323b1499e01776ea5ce307?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/cyberorg/" title="Posts by Jigish Gohil">Jigish Gohil</a> (84)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/c94eecfd9b7519aa4e106164c71938db?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/c94eecfd9b7519aa4e106164c71938db?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/jsrain/" title="Posts by Jiri Srain">Jiri Srain</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/248d14d0cc663817e9ea2e5d3915d81d?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/248d14d0cc663817e9ea2e5d3915d81d?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/jsuchome/" title="Posts by Jiří Suchomel">Jiří Suchomel</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/abd6ad5514475b1ebfa926808c403ad1?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/abd6ad5514475b1ebfa926808c403ad1?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/gogga/" title="Posts by Johan Kotze">Johan Kotze</a> (5)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/20896f1aedb65d7bec41c256479a8c51?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/20896f1aedb65d7bec41c256479a8c51?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/jaom7/" title="Posts by José Oramas M.">José Oramas M.</a> (6)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/5d601001fada5a97a0c12f3914a23056?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/5d601001fada5a97a0c12f3914a23056?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/jreidinger/" title="Posts by Josef Reidinger">Josef Reidinger</a> (16)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/c0b2bd9e77ad555fd152d1f1e6ba941c?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/c0b2bd9e77ad555fd152d1f1e6ba941c?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/jnweiger/" title="Posts by Juergen Weigert">Juergen Weigert</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/6741359d1ed61956c5a97b0abcb38ac2?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/6741359d1ed61956c5a97b0abcb38ac2?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/ungaman/" title="Posts by Julio Vannini">Julio Vannini</a> (9)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/e99d62a139171d890638196c4f4a1454?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/e99d62a139171d890638196c4f4a1454?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/eri_zaq/" title="Posts by k0da">Dinar Valeev</a> (5)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/35442b494f156dc790d0991e4f6b3a60?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/35442b494f156dc790d0991e4f6b3a60?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/kdupuy9/" title="Posts by Kevin Yeaux">Kevin "Yeaux" Dupuy</a> (11)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/f1370548d8ba45fc5601d5398f443e2a?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/f1370548d8ba45fc5601d5398f443e2a?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/kfreitag/" title="Posts by Klaas Freitag">Klaas Freitag</a> (55)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9b156676c0210ba003191ec5c399c5a0?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9b156676c0210ba003191ec5c399c5a0?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/lrupp/" title="Posts by kl_eisbaer">Lars Vogdt</a> (11)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/8b6214136e12dcaf922fc54797c42758?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/8b6214136e12dcaf922fc54797c42758?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/lnussel/" title="Posts by lnussel">Ludwig Nussel</a> (11)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9b1772f92b6518e084164c28075868dc?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9b1772f92b6518e084164c28075868dc?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/medwin/" title="Posts by M. Edwin Zakaria">M. Edwin Zakaria</a> (4)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/8f947802c8278f7de589d948d49d1c97?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/8f947802c8278f7de589d948d49d1c97?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/marcus_h/" title="Posts by Marcus Hüwe">Marcus Hüwe</a> (39)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/a7c3995461464bff8fc20e6f908abadd?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/a7c3995461464bff8fc20e6f908abadd?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/msmeissn/" title="Posts by Marcus Meissner">Marcus Meissner</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/0165e588414858c88d99b90227280b1f?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/0165e588414858c88d99b90227280b1f?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/marcusmoeller/" title="Posts by Marcus Moeller">Marcus Moeller</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/5f320b472b5d1c5ca6e446953cb3d371?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/5f320b472b5d1c5ca6e446953cb3d371?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/sax2/" title="Posts by Marcus Schaefer">Marcus Schaefer</a> (4)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/ecd8f651819469eaf51b8b530255f341?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/ecd8f651819469eaf51b8b530255f341?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/mlasars/" title="Posts by Martin Lasarsch">Martin Lasarsch</a> (8)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/ab07ba0fd8f0c45b93e0bdbacc3ef144?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/ab07ba0fd8f0c45b93e0bdbacc3ef144?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/martinmohring/" title="Posts by Martin Mohring">Martin Mohring</a> (11)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9619e4fc93c7d6573592b1cd384fa56a?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9619e4fc93c7d6573592b1cd384fa56a?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/vavai/" title="Posts by Masim &quot;Vavai&quot; Sugianto">Masim "Vavai" Sugianto</a> (20)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/e245b64d557ff67adb3f20638e1c9817?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/e245b64d557ff67adb3f20638e1c9817?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/mlandres/" title="Posts by Michael Andres">Michael Andres</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/7db9f4f49d947c634b116b5b22d0d11d?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/7db9f4f49d947c634b116b5b22d0d11d?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/michl19/" title="Posts by Michael Löffler">Michael Löffler</a> (7)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/c6829cd04b1947a249504274a3b8954f?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/c6829cd04b1947a249504274a3b8954f?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/michal-m/" title="Posts by Michal Marek">Michal Marek</a> (7)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/43f1417e56acda517176e140478ce3d6?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/43f1417e56acda517176e140478ce3d6?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/mvyskocil/" title="Posts by Michal Vyskocil">Michal Vyskocil</a> (12)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/4f67ab763c02707130c404ff6bc35bc0?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/4f67ab763c02707130c404ff6bc35bc0?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/migbarajas/" title="Posts by Miguel Angel Barajas Hernandez">Miguel Angel Barajas Hernandez</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/615628ff1f2a270d7b809f9be6d739bd?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/615628ff1f2a270d7b809f9be6d739bd?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/mrdocs/" title="Posts by mrdocs">P Linnell</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/d83ba9917b5c73d8ea6dc40e13828a2a?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/d83ba9917b5c73d8ea6dc40e13828a2a?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/ketheriel/" title="Posts by Nelson Marques">Nelson Marques</a> (55)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/6eaf6fd8ab1bd7593b8ada5a18b0ecb3?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/6eaf6fd8ab1bd7593b8ada5a18b0ecb3?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/holden87/" title="Posts by Nenad Latinović">Nenad Latinović</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/24d359e8a9d8c616e55d7f4f348c6f1c?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/24d359e8a9d8c616e55d7f4f348c6f1c?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/nikanth/" title="Posts by Nikanth Karthikesan">Nikanth Karthikesan</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/0f4da55be111d6640f56f3b5166b64b0?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/0f4da55be111d6640f56f3b5166b64b0?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/poeml/" title="Posts by Peter Pöml">Peter Pöml</a> (4)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/b8cea958d8c775ca07fcda50d027bcbe?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/b8cea958d8c775ca07fcda50d027bcbe?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/pgajdos/" title="Posts by Petr Gajdos">Petr Gajdos</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/bd71ffa5ce4ce3c4a1802c6aa0d9ca37?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/bd71ffa5ce4ce3c4a1802c6aa0d9ca37?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/pmladek/" title="Posts by Petr Mladek">Petr Mladek</a> (60)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/b38a833149d2d81ac3ce73dc868f20f6?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/b38a833149d2d81ac3ce73dc868f20f6?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/puzel/" title="Posts by Petr Uzel">Petr Uzel</a> (5)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9c79fcaede7330f7e30d200100df9194?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9c79fcaede7330f7e30d200100df9194?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/rawang/" title="Posts by Ray Wang">Ray Wang</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/0f2a44ee48448ded558b90d55ed52b28?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/0f2a44ee48448ded558b90d55ed52b28?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/rwooninck/" title="Posts by Raymond Wooninck">Raymond Wooninck</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/1df0fbf4b7fb2b10e93b8d84795a6b4a?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/1df0fbf4b7fb2b10e93b8d84795a6b4a?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/amonthoth/" title="Posts by Ricardo Chung">Ricardo Chung</a> (7)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/fdd7251cf3e8f4d193e4f7f59238303a?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/fdd7251cf3e8f4d193e4f7f59238303a?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/ricardovarassantana/" title="Posts by Ricardo Varas Santana">Ricardo Varas Santana</a> (7)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/c0cff57a7e00b3ad4107e5627460b153?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/c0cff57a7e00b3ad4107e5627460b153?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/rbos/" title="Posts by Richard Bos">Richard Bos</a> (11)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/ed5b1491aa79201a8eaf93bf57193584?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/ed5b1491aa79201a8eaf93bf57193584?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/rjschwei/" title="Posts by rjschwei">Robert Schweikert</a> (15)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/6c9af0fa89f64b30eb228ee80c30595b?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/6c9af0fa89f64b30eb228ee80c30595b?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/g0nz0/" title="Posts by Rossana Motta">Rossana Motta</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/abcd749a57b47babab9ac7c8e35ae13a?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/abcd749a57b47babab9ac7c8e35ae13a?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/rhorstkoetter/" title="Posts by Rupert Horstkötter">Rupert Horstkötter</a> (10)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9d46eeed4de01dd50e3fd70bd660969b?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9d46eeed4de01dd50e3fd70bd660969b?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/saigkill/" title="Posts by Sascha Manns">Sascha Manns</a> (66)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/4da4097a3ca6d06d5c5c2423c257e7c5?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/4da4097a3ca6d06d5c5c2423c257e7c5?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/idulk/" title="Posts by Saydul Akram">Saydul Akram</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/be78d27ac14d16135e3f35e8612fa87c?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/be78d27ac14d16135e3f35e8612fa87c?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/sts301/" title="Posts by Sebastian Schöbinger">Sebastian Schöbinger</a> (4)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/25f795db5466abdabad1ff5ead7c152d?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/25f795db5466abdabad1ff5ead7c152d?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/freespacer/" title="Posts by Sebastian Siebert">Sebastian Siebert</a> (6)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/102a74f8297a2c355f7d00e833a0d942?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/102a74f8297a2c355f7d00e833a0d942?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/sfalken/" title="Posts by sfalken">Shawn Dunn</a> (2)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/b75fc92bf436b8b99b404093eb5959e6?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/b75fc92bf436b8b99b404093eb5959e6?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/visnov/" title="Posts by Stanislav Visnovsky">Stanislav Visnovsky</a> (7)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/da5a74c3532da395c68bca5982852e81?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/da5a74c3532da395c68bca5982852e81?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/haass/" title="Posts by Stefan Haas">Stefan Haas</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/be695f4500ece3e8a9acc31270099de1?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/be695f4500ece3e8a9acc31270099de1?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/sh-sh-sh/" title="Posts by Stefan Hundhammer">Stefan Hundhammer</a> (5)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/922d00b5cf8398f512c781a792598d23?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/922d00b5cf8398f512c781a792598d23?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/schubi2/" title="Posts by Stefan Schubert">Stefan Schubert</a> (7)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/8b5badfd72c932cf36698242b1610836?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/8b5badfd72c932cf36698242b1610836?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/snwint/" title="Posts by Steffen Winterfeldt">Steffen Winterfeldt</a> (4)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/ff345c5a6b06ad0889db1f1ff52a6489?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/ff345c5a6b06ad0889db1f1ff52a6489?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/sjayaraman/" title="Posts by Suresh Jayaraman">Suresh Jayaraman</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/713186a58c872c6bdfd2888469037921?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/713186a58c872c6bdfd2888469037921?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/froh/" title="Posts by Susanne Oberhauser">Susanne Oberhauser</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/ab332ba11182affd7a59e701ac43e622?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/ab332ba11182affd7a59e701ac43e622?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/tgoettlicher/" title="Posts by Thomas Göttlicher">Thomas Göttlicher</a> (6)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/100154b0e5aba0626e8db6191e264783?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/100154b0e5aba0626e8db6191e264783?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/thomasrjones/" title="Posts by Thomas Jones">Thomas Jones</a> (1)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/a2ab55809fc9fc1cde1c4a519e283ef8?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/a2ab55809fc9fc1cde1c4a519e283ef8?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/thomas-schraitle/" title="Posts by Thomas Schraitle">Thomas Schraitle</a> (26)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/926aae47e9d1677af3799a66f39f330d?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/926aae47e9d1677af3799a66f39f330d?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/toganm/" title="Posts by Togan Muftuoglu">Togan Muftuoglu</a> (3)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/8389419eead797f59285b4da04d33e3d?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/8389419eead797f59285b4da04d33e3d?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/illuusio/" title="Posts by Tuukka Pasanen">Tuukka Pasanen</a> (36)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/ae5863e449a99ef82a76b2778262c9d7?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/ae5863e449a99ef82a76b2778262c9d7?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/wstephenson/" title="Posts by Will Stephenson">Will Stephenson</a> (22)</li>
+<li><img alt='' src='https://secure.gravatar.com/avatar/9353200822a6476865b2f294680f17ce?s=32&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/9353200822a6476865b2f294680f17ce?s=64&amp;d=mm&amp;r=g 2x' class='avatar avatar-32 photo' height='32' width='32' /><a href="https://lizards.opensuse.org/author/yast-team/" title="Posts by Yast Team">YaST Team</a> (20)</li>
+</ul>					</li>	<li id="archives-4" class="widget box box-shadow widget_archive"><h3 class="box-subheader">Archives</h3>		<ul>
+			<li><a href='https://lizards.opensuse.org/2016/12/'>December 2016</a>&nbsp;(1)</li>
+	<li><a href='https://lizards.opensuse.org/2016/11/'>November 2016</a>&nbsp;(3)</li>
+	<li><a href='https://lizards.opensuse.org/2016/10/'>October 2016</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2016/09/'>September 2016</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2016/08/'>August 2016</a>&nbsp;(3)</li>
+	<li><a href='https://lizards.opensuse.org/2016/07/'>July 2016</a>&nbsp;(4)</li>
+	<li><a href='https://lizards.opensuse.org/2016/06/'>June 2016</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2016/05/'>May 2016</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2016/04/'>April 2016</a>&nbsp;(1)</li>
+	<li><a href='https://lizards.opensuse.org/2016/03/'>March 2016</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2016/02/'>February 2016</a>&nbsp;(4)</li>
+	<li><a href='https://lizards.opensuse.org/2016/01/'>January 2016</a>&nbsp;(4)</li>
+	<li><a href='https://lizards.opensuse.org/2015/12/'>December 2015</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2015/11/'>November 2015</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2015/10/'>October 2015</a>&nbsp;(3)</li>
+	<li><a href='https://lizards.opensuse.org/2015/09/'>September 2015</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2015/08/'>August 2015</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2015/07/'>July 2015</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2015/06/'>June 2015</a>&nbsp;(3)</li>
+	<li><a href='https://lizards.opensuse.org/2015/05/'>May 2015</a>&nbsp;(12)</li>
+	<li><a href='https://lizards.opensuse.org/2015/04/'>April 2015</a>&nbsp;(8)</li>
+	<li><a href='https://lizards.opensuse.org/2015/03/'>March 2015</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2015/02/'>February 2015</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2015/01/'>January 2015</a>&nbsp;(7)</li>
+	<li><a href='https://lizards.opensuse.org/2014/12/'>December 2014</a>&nbsp;(5)</li>
+	<li><a href='https://lizards.opensuse.org/2014/11/'>November 2014</a>&nbsp;(3)</li>
+	<li><a href='https://lizards.opensuse.org/2014/10/'>October 2014</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2014/09/'>September 2014</a>&nbsp;(4)</li>
+	<li><a href='https://lizards.opensuse.org/2014/08/'>August 2014</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2014/07/'>July 2014</a>&nbsp;(5)</li>
+	<li><a href='https://lizards.opensuse.org/2014/06/'>June 2014</a>&nbsp;(7)</li>
+	<li><a href='https://lizards.opensuse.org/2014/05/'>May 2014</a>&nbsp;(9)</li>
+	<li><a href='https://lizards.opensuse.org/2014/04/'>April 2014</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2014/03/'>March 2014</a>&nbsp;(9)</li>
+	<li><a href='https://lizards.opensuse.org/2014/02/'>February 2014</a>&nbsp;(9)</li>
+	<li><a href='https://lizards.opensuse.org/2014/01/'>January 2014</a>&nbsp;(10)</li>
+	<li><a href='https://lizards.opensuse.org/2013/12/'>December 2013</a>&nbsp;(9)</li>
+	<li><a href='https://lizards.opensuse.org/2013/11/'>November 2013</a>&nbsp;(10)</li>
+	<li><a href='https://lizards.opensuse.org/2013/10/'>October 2013</a>&nbsp;(10)</li>
+	<li><a href='https://lizards.opensuse.org/2013/09/'>September 2013</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2013/08/'>August 2013</a>&nbsp;(7)</li>
+	<li><a href='https://lizards.opensuse.org/2013/07/'>July 2013</a>&nbsp;(3)</li>
+	<li><a href='https://lizards.opensuse.org/2013/06/'>June 2013</a>&nbsp;(7)</li>
+	<li><a href='https://lizards.opensuse.org/2013/05/'>May 2013</a>&nbsp;(4)</li>
+	<li><a href='https://lizards.opensuse.org/2013/04/'>April 2013</a>&nbsp;(4)</li>
+	<li><a href='https://lizards.opensuse.org/2013/03/'>March 2013</a>&nbsp;(7)</li>
+	<li><a href='https://lizards.opensuse.org/2013/02/'>February 2013</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2013/01/'>January 2013</a>&nbsp;(3)</li>
+	<li><a href='https://lizards.opensuse.org/2012/12/'>December 2012</a>&nbsp;(3)</li>
+	<li><a href='https://lizards.opensuse.org/2012/10/'>October 2012</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2012/09/'>September 2012</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2012/08/'>August 2012</a>&nbsp;(5)</li>
+	<li><a href='https://lizards.opensuse.org/2012/07/'>July 2012</a>&nbsp;(12)</li>
+	<li><a href='https://lizards.opensuse.org/2012/06/'>June 2012</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2012/05/'>May 2012</a>&nbsp;(4)</li>
+	<li><a href='https://lizards.opensuse.org/2012/04/'>April 2012</a>&nbsp;(4)</li>
+	<li><a href='https://lizards.opensuse.org/2012/03/'>March 2012</a>&nbsp;(5)</li>
+	<li><a href='https://lizards.opensuse.org/2012/02/'>February 2012</a>&nbsp;(2)</li>
+	<li><a href='https://lizards.opensuse.org/2012/01/'>January 2012</a>&nbsp;(5)</li>
+	<li><a href='https://lizards.opensuse.org/2011/12/'>December 2011</a>&nbsp;(10)</li>
+	<li><a href='https://lizards.opensuse.org/2011/11/'>November 2011</a>&nbsp;(6)</li>
+	<li><a href='https://lizards.opensuse.org/2011/10/'>October 2011</a>&nbsp;(5)</li>
+	<li><a href='https://lizards.opensuse.org/2011/09/'>September 2011</a>&nbsp;(9)</li>
+	<li><a href='https://lizards.opensuse.org/2011/08/'>August 2011</a>&nbsp;(12)</li>
+	<li><a href='https://lizards.opensuse.org/2011/07/'>July 2011</a>&nbsp;(14)</li>
+	<li><a href='https://lizards.opensuse.org/2011/06/'>June 2011</a>&nbsp;(11)</li>
+	<li><a href='https://lizards.opensuse.org/2011/05/'>May 2011</a>&nbsp;(18)</li>
+	<li><a href='https://lizards.opensuse.org/2011/04/'>April 2011</a>&nbsp;(16)</li>
+	<li><a href='https://lizards.opensuse.org/2011/03/'>March 2011</a>&nbsp;(26)</li>
+	<li><a href='https://lizards.opensuse.org/2011/02/'>February 2011</a>&nbsp;(16)</li>
+	<li><a href='https://lizards.opensuse.org/2011/01/'>January 2011</a>&nbsp;(23)</li>
+	<li><a href='https://lizards.opensuse.org/2010/12/'>December 2010</a>&nbsp;(27)</li>
+	<li><a href='https://lizards.opensuse.org/2010/11/'>November 2010</a>&nbsp;(18)</li>
+	<li><a href='https://lizards.opensuse.org/2010/10/'>October 2010</a>&nbsp;(21)</li>
+	<li><a href='https://lizards.opensuse.org/2010/09/'>September 2010</a>&nbsp;(16)</li>
+	<li><a href='https://lizards.opensuse.org/2010/08/'>August 2010</a>&nbsp;(21)</li>
+	<li><a href='https://lizards.opensuse.org/2010/07/'>July 2010</a>&nbsp;(20)</li>
+	<li><a href='https://lizards.opensuse.org/2010/06/'>June 2010</a>&nbsp;(33)</li>
+	<li><a href='https://lizards.opensuse.org/2010/05/'>May 2010</a>&nbsp;(29)</li>
+	<li><a href='https://lizards.opensuse.org/2010/04/'>April 2010</a>&nbsp;(24)</li>
+	<li><a href='https://lizards.opensuse.org/2010/03/'>March 2010</a>&nbsp;(29)</li>
+	<li><a href='https://lizards.opensuse.org/2010/02/'>February 2010</a>&nbsp;(22)</li>
+	<li><a href='https://lizards.opensuse.org/2010/01/'>January 2010</a>&nbsp;(20)</li>
+	<li><a href='https://lizards.opensuse.org/2009/12/'>December 2009</a>&nbsp;(15)</li>
+	<li><a href='https://lizards.opensuse.org/2009/11/'>November 2009</a>&nbsp;(21)</li>
+	<li><a href='https://lizards.opensuse.org/2009/10/'>October 2009</a>&nbsp;(17)</li>
+	<li><a href='https://lizards.opensuse.org/2009/09/'>September 2009</a>&nbsp;(22)</li>
+	<li><a href='https://lizards.opensuse.org/2009/08/'>August 2009</a>&nbsp;(28)</li>
+	<li><a href='https://lizards.opensuse.org/2009/07/'>July 2009</a>&nbsp;(37)</li>
+	<li><a href='https://lizards.opensuse.org/2009/06/'>June 2009</a>&nbsp;(41)</li>
+	<li><a href='https://lizards.opensuse.org/2009/05/'>May 2009</a>&nbsp;(40)</li>
+	<li><a href='https://lizards.opensuse.org/2009/04/'>April 2009</a>&nbsp;(30)</li>
+	<li><a href='https://lizards.opensuse.org/2009/03/'>March 2009</a>&nbsp;(20)</li>
+	<li><a href='https://lizards.opensuse.org/2009/02/'>February 2009</a>&nbsp;(21)</li>
+	<li><a href='https://lizards.opensuse.org/2009/01/'>January 2009</a>&nbsp;(27)</li>
+	<li><a href='https://lizards.opensuse.org/2008/12/'>December 2008</a>&nbsp;(23)</li>
+	<li><a href='https://lizards.opensuse.org/2008/11/'>November 2008</a>&nbsp;(12)</li>
+	<li><a href='https://lizards.opensuse.org/2008/10/'>October 2008</a>&nbsp;(23)</li>
+	<li><a href='https://lizards.opensuse.org/2008/09/'>September 2008</a>&nbsp;(40)</li>
+	<li><a href='https://lizards.opensuse.org/2008/08/'>August 2008</a>&nbsp;(24)</li>
+	<li><a href='https://lizards.opensuse.org/2008/07/'>July 2008</a>&nbsp;(12)</li>
+	<li><a href='https://lizards.opensuse.org/2008/06/'>June 2008</a>&nbsp;(28)</li>
+	<li><a href='https://lizards.opensuse.org/2008/05/'>May 2008</a>&nbsp;(26)</li>
+	<li><a href='https://lizards.opensuse.org/2008/04/'>April 2008</a>&nbsp;(1)</li>
+		</ul>
+		</li>      
+    <!-- </div> -->
+
+</div>
+</div>
+<!-- End: Main Content Area -->
+
+  
+    
+  <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.6.1'></script>
+
+</body>
+</html>


### PR DESCRIPTION
The script imports the YaST blog posts from lizards.opensuse.org and converts them into the Markdown format to use in a Jekyll based blog.

The code is not great and could be implemented better (esp. some parts from the RSS importer could be shared with the HTML importer).

But as this is just one-shot tool (run&forget) I did not want to spend/waste too much time with it.

### The main point is to have it for the future reference if somebody needs to parse/modify HTML files, download images, convert HTML to Markdown,...

So please be kind with the review, I really do not want to spend more time here... :wink: 