### PR TITLE
Updated the branch protection script

### DIFF
--- a/github/protect_branches/Gemfile
+++ b/github/protect_branches/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
+gem "netrc"
 gem "octokit"
+gem "parallel"


### PR DESCRIPTION
- Read the credentials from the `~/.netrc` file if it is present (more convenient configuration, it can be used by some other tools)
- Added another SLE-10 regexp (used by some repositories)
- Use a special accept header to avoid printing a Beta warning
- Use the [parallel](https://github.com/grosser/parallel) gem to speed up the script (on a quad core CPU it runs almost 4x faster)