### PR TITLE
[y2m] Fix Github API parsing to find module names

### DIFF
--- a/git/y2m/y2m
+++ b/git/y2m/y2m
@@ -37,7 +37,7 @@ get_repos()
   for orgname in "$@"
   do for page in 1 2 3 4 5
      do # workaround for github's silly pagination
-        curl -s "https://api.github.com/orgs/${orgname}/repos?page=${page}&per_page=100" | grep "\"name\":" | sed -e "s/^.*name\": \"\(.*\)\",.*$/\1/"
+        curl -s "https://api.github.com/orgs/${orgname}/repos?page=${page}&per_page=100" | grep "\"full_name\":" | sed -e "s/^.*full_name\": \"${orgname}\/\(.*\)\",.*$/\1/"
      done
   done
 }


### PR DESCRIPTION
Github API response in JSON contains "name" for both repository name as
well as for license. Because of this, y2m would return "yast-add-on GNU
General Public License v2.0.." as the list of modules for YaST.