### PR TITLE
[y2m] Set appropriate organization for ALL YaST modules

### DIFF
--- a/git/y2m/y2m
+++ b/git/y2m/y2m
@@ -227,7 +227,7 @@ do
         ;;
     libyui) MODDIRNAME=${M}
         ;;
-    y2r) MODDIRNAME=${M}
+    y2r|skelcd*|rub*|zombie*|yast*|docker*|blog|burndown|patterns*|system*|travis*|ci*|auto*|aytest*|helper*|YaST*|os*) MODDIRNAME=${M}
         ORG="yast"
 	;;
     ruby) MODDIRNAME=${M}


### PR DESCRIPTION
Without this change, y2m would not clone a lot of modules - around 76 YaST modules would not be cloned or updated.