### PR TITLE
Script for adding build matrix into GitHub Actions

### DIFF
--- a/github/github_actions/add_build_matrix.rb
+++ b/github/github_actions/add_build_matrix.rb
@@ -1,0 +1,115 @@
+#!/usr/bin/env ruby
+
+# This script adds a build matrix
+#
+# You need admin access rights to temporarily disable the GitHub branch protection
+# and allow direct push to GitHub without a review".
+#
+
+require_relative "gh_helpers"
+
+# the GitHub organization
+GH_ORG = "yast".freeze
+
+# optionally do not confirm the changes
+CONFIRM = ENV["CONFIRM"] != "0"
+
+# subdirectory where to clone Git repositories
+GIT_CHECKOUT_DIR = "github".freeze
+
+def workflow_files
+  Dir.glob(".github/workflows/*.yml") + Dir.glob(".github/workflows/*.yaml")
+end
+
+def run_on_tw(content, job)
+  content.gsub!(
+    /(#{job}:(?:(?!distro).)*distro: )[^\n]*\n/m,
+    "\\1 [ \"tumbleweed\", \"leap_latest\" ]\n"
+  )
+end
+
+def modify_workflow(content)
+  new_content = content.dup
+
+  snippet = <<-EOT.chomp
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [ "leap_latest" ]
+
+    container:
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
+EOT
+
+  new_content.gsub!(
+    /^\s*container:\n*\s*image:\s*registry\.opensuse\.org\/yast\/head\/containers\/yast-ruby:latest/,
+    snippet
+  )
+
+  snippet = <<-EOT.chomp
+      # send it only from the TW build to avoid duplicate submits
+      if: ${{ matrix.distro == 'tumbleweed' }}
+      uses: coverallsapp/github-action@master
+EOT
+
+  new_content.gsub!(
+    /^\s*uses: coverallsapp\/github-action@master/,
+    snippet
+  )
+
+  run_on_tw(new_content, "Tests")
+  run_on_tw(new_content, "Package")
+
+  new_content
+end
+
+def update_workflow(file)
+  # unfortunately we cannot use "YAML.load_file" and ".to_yaml" later as it would
+  # remove the comments and reformat the document :-(
+  content = File.read(file)
+
+  # skip if the Ruby image is not present
+  if !content.include?("registry.opensuse.org/yast/head/containers/yast-ruby") ||
+      # or the build matrix is already present
+      content.include?("distro: [ \"leap_latest\" ]")
+
+    return false
+  end
+
+  new_content = modify_workflow(content)
+
+  changed = new_content != content
+  File.write(file, new_content) if changed
+  changed
+end
+
+client = gh_client
+
+gh_repos(client, GH_ORG).each do |repo|
+  # where to checkout the Git repository
+  checkout_dir = File.join(GIT_CHECKOUT_DIR, repo.name)
+
+  # already cloned?
+  if !File.directory?(checkout_dir)
+    puts
+    # we do not need the complete history, use depth=1
+    system("git clone --depth 1 #{repo.ssh_url} #{checkout_dir}")
+  end
+
+  Dir.chdir(checkout_dir) do
+    # no change
+    next if workflow_files.map { |f| update_workflow(f) }.none?
+
+    puts "Updating GitHub Actions:"
+    system("git --no-pager diff")
+
+    next if CONFIRM && !commit_confirmed?
+
+    system("git commit -a -m \"Added build matrix to GitHub Actions\"")
+
+    with_unprotected(client, repo.full_name, repo.default_branch) do
+      system("git push")
+    end
+  end
+end

--- a/github/github_actions/gh_helpers.rb
+++ b/github/github_actions/gh_helpers.rb
@@ -1,0 +1,82 @@
+
+# install missing gems
+if !File.exist?("./.vendor")
+  puts "Installing the needed Rubygems to ./.vendor/bundle ..."
+  system "bundle install --path .vendor/bundle"
+end
+
+require "rubygems"
+require "bundler/setup"
+
+require "octokit"
+
+# create the octokit client
+def gh_client
+  # use ~/.netrc ?
+  netrc = File.join(Dir.home, ".netrc")
+  client_options = if ENV["GH_TOKEN"]
+    # Generate at https://github.com/settings/tokens
+    { access_token: ENV["GH_TOKEN"] }
+  elsif File.exist?(netrc) && File.read(netrc).match(/^machine api.github.com/)
+    # see https://github.com/octokit/octokit.rb#authentication
+    { netrc: true }
+  else
+    $stderr.puts "Error: The Github access token is not set."
+    $stderr.puts "Pass it via the 'GH_TOKEN' environment variable"
+    $stderr.puts "or write it to the ~/.netrc file."
+    $stderr.puts "See https://github.com/octokit/octokit.rb#using-a-netrc-file"
+    exit 1
+  end
+
+  client = Octokit::Client.new(client_options)
+  client.auto_paginate = true
+
+  client
+end
+
+def gh_repos(client, org)
+  puts "Reading #{org.inspect} repositories at GitHub..."
+  git_repos = client.list_repositories(org)
+  puts "Found #{git_repos.size} Git repositories\n\n"
+  git_repos
+end
+
+def with_unprotected(client, repo, branch, &block)
+  return unless block_given?
+
+  client.unprotect_branch(repo, branch)
+
+  begin
+    block.call
+  ensure
+    # GitHub branch protection options - require PR reviews also for the admins
+    # https://octokit.github.io/octokit.rb/Octokit/Client/Repositories.html#protect_branch-instance_method
+    # https://docs.github.com/en/rest/reference/repos#update-branch-protection
+    options = {
+      "enforce_admins"                => true,
+      "required_pull_request_reviews" => {
+        "require_code_owner_reviews" => true,
+        "include_admins"             => true
+      }
+    }
+
+    client.protect_branch(repo, branch, options)
+  end
+end
+
+# ask user to confirm the changes before git push
+def commit_confirmed?
+  msg = "\nCommit the change? [Y/n] "
+  print msg
+
+  input = nil
+  loop do
+    input = $stdin.gets.strip
+    break if ["Y", "y", "N", "n", ""].include?(input)
+
+    print "Invalid input#{msg}"
+  end
+
+  # assume approval by default, just pressing [Enter] (empty string) is enough
+  ["Y", "y", ""].include?(input)
+end


### PR DESCRIPTION
- Just for reference, this is the script I used for adding the GitHub Action build matrix
- The result looks like this: https://github.com/yast/yast-autoinstallation/commit/a50cf8e2455342ccef96d5dc057d03ca7f449558#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f
- Note: the separate `gh_helpers.rb` file should be shared by the future similar scripts