### PR TITLE
Added Overcommit scripts

### DIFF
--- a/git/overcommit/README.md
+++ b/git/overcommit/README.md
@@ -1,0 +1,119 @@
+# Overcommit
+
+The [Overcommit](https://github.com/sds/overcommit) tool can configure
+and manage Git hooks in an easy way. This directory contains helper scripts for
+adding some nice hooks to the YaST Git checkout.
+
+The motivation is to avoid "make Rubocop happy" commits or avoid committing
+code which breaks unit tests. We run the CI builds so we would find the issues
+anyway but with this tool you can find the problems sooner and faster.
+
+See https://blog.ladslezak.cz/2016/06/06/overcommit/ for example usage.
+
+## Requirements
+
+Install the `overcommit` Ruby gem from [YaST:Head](
+https://build.opensuse.org/project/show/YaST:Head) OBS project.
+
+1. Add the repository:
+
+   ```shell
+   # openSUSE Leap
+   zypper addrepo -r "https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Leap_${releasever}" YaST:Head
+   # openSUSE Tumbleweed
+   zypper addrepo -r https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed YaST:Head
+   ```
+
+2. Install the packages:
+
+   ```shell
+   # hunspell is used for spell checking the commit messages
+   zypper install "rubygem(overcommit)" hunspell
+   ```
+
+## Usage
+
+## Generating the Config Files and Installing Overcommit Hooks
+
+The `install_overcommit.rb` script generates the default `.overcommit.yml`
+configuration files and installs the Overcommit hooks in the specified path.
+The target path is searched for Git repositories recursively, you can install
+the hooks to all YaST Git repositories at once, just use the parent path.
+
+If the configuration file already exists it is not created to not possibly
+overwrite the manual changes. If you want to re-generate the configuration you have
+to delete it first.
+
+```shell
+./install_overcommit.rb <directory>
+```
+
+The `.overcommit.yml` configuration file is not added to the Git index but is
+listed in the `.git/info/exclude` file so it is ignored by Git even without
+touching the `.gitignore` file.
+
+### The Created Configuration
+
+The default created configuration does these actions:
+
+#### On `git commit`
+
+- Runs a spell checker against the commit message. The potential mistakes are
+  reported only as warnings, the commit to Git is not blocked but it is a good
+  idea to check whether there is some typo in the message or not.
+- Checks whether the commit targets a forbidden branch like `master` or
+  `SLE-15-SP4` (any changes to these branches needs to be done via pull requests,
+  GitHub would reject the push later anyway but it is better to notice this sooner)
+- Runs a Rubocop check when the `.rubocop.yml` file is present in the repository.
+
+#### On `git push`
+
+- Runs the RSpec unit tests, `rake test:unit`) when a `Rakefile` is found
+  or runs `make check` when a `Makefile` is found.
+
+Of course, you might add some more checks to the configuration or modify the
+defaults, see more details in the [Overcommit documentation](
+https://github.com/sds/overcommit#built-in-hooks).
+
+## Generating Custom Dictionary
+
+The default Git hooks include running a spell checker for the commit messages.
+To avoid many false positives you can import a custom YaST dictionary which
+contains a lot of YaST specific words.
+
+```shell
+./install_custom_dictionary.rb
+```
+
+This script downloads the [custom YaST dictionary](
+https://github.com/yast/yast.github.io/blob/master/.spell.yml) and installs it
+into the `~/.hunspell_en_US` file. The existing words are kept.
+
+## Disabling Overcommit
+
+Sometimes you want to perform a Git operation even when an Overcommit hook fails.
+For example the unit tests might fail because you are working in a SLE-12 branch
+but you have SLE15/Leap15 installed in your system.
+
+In that case you can disable the Overcommit hooks temporarily by setting the
+environment variable `OVERCOMMIT_DISABLE=1` for that Git command.
+
+```shell
+OVERCOMMIT_DISABLE=1 git push
+```
+
+If you want to disable Overcommit permanently then run in the respective Git
+checkout this command
+
+```shell
+overcommit --uninstall
+```
+
+## Updating the Configuration
+
+For [security reasons](https://github.com/sds/overcommit#security) Overcommit
+tracks the content of the `.overcommit.yml` configuration file. You need to run
+`overcommit --sign` whenever you touch that file.
+
+If the change was not done by you then you should carefully check the file
+content.

--- a/git/overcommit/install_custom_dictionary.rb
+++ b/git/overcommit/install_custom_dictionary.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+#
+# This scripts downloads the YaST custom dictionary from
+# https://github.com/yast/yast.github.io/blob/master/.spell.yml file
+# and saves the dictionary to the $HOME/.hunspell_en_US file
+# so it can be used by hunspell for spell checking the Git commit messages
+# by overcommit.
+#
+
+require "open-uri"
+require "yaml"
+
+URL = "https://raw.githubusercontent.com/yast/yast.github.io/master/.spell.yml"
+# the default custom dictionary for "en_US" language
+DICTIONARY_FILE = "#{Dir.home}/.hunspell_en_US"
+
+text = URI(URL).read
+dict = YAML.safe_load(text)["dictionary"]
+
+# merge with the existing dictionary
+dict += File.read(DICTIONARY_FILE).split("\n") if File.exist?(DICTIONARY_FILE)
+
+# some extra words
+dict += [
+  "YaST",
+  "bsc",
+  "boo",
+  "jsc"
+]
+
+dict = dict.sort_by(&:downcase)
+dict.uniq!
+dict.reject!(&:empty?)
+
+puts "Writing #{dict.size} custom words to #{DICTIONARY_FILE}"
+File.write(DICTIONARY_FILE, dict.join("\n"))

--- a/git/overcommit/install_overcommit.rb
+++ b/git/overcommit/install_overcommit.rb
@@ -21,7 +21,7 @@ require "find"
 OVERCOMMIT_CFG = ".overcommit.yml"
 
 def install_overcommit(dir, template)
-  # skip if overcommit it is already present
+  # skip if overcommit is already present
   overcommit_file = File.join(dir, OVERCOMMIT_CFG)
   return if File.exist?(overcommit_file)
 

--- a/git/overcommit/install_overcommit.rb
+++ b/git/overcommit/install_overcommit.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+#
+# This scripts automatically installs the Overcommit Git hooks.
+# It scans the subdirectories recursively for Git repositories.
+#
+# Usage:
+#   ./install_overcommit.rb [path]
+#
+# If path is given it scans that directory, if not specified it scans
+# the current directory.
+#
+# See https://github.com/sds/overcommit for more details about
+# the Overcommit tool.
+
+require "erb"
+require "find"
+
+# Overcommit configuration file
+OVERCOMMIT_CFG = ".overcommit.yml"
+
+def install_overcommit(dir, template)
+  # skip if overcommit it is already present
+  overcommit_file = File.join(dir, OVERCOMMIT_CFG)
+  return if File.exist?(overcommit_file)
+
+  @add_rubocop = File.exist?(File.join(dir, ".rubocop.yml")) && File.exist?(File.join(dir, "Rakefile"))
+
+  @test_command = if File.exist?(File.join(dir, "Makefile.cvs"))
+    ["make", "check"]
+  # regexp from the test:unit rake task
+  elsif !Dir["#{dir}/**/test/**/*_{spec,test}.rb"].empty? && File.exist?(File.join(dir, "Rakefile"))
+    ["rake", "test:unit"]
+  end
+
+  # "<>" means no extra space after <% %>
+  erb = ERB.new(template, nil, "<>")
+  # write the config file
+  File.write(overcommit_file, erb.result(binding))
+
+  # hide the file for git, append the file name to .git/info/exclude
+  File.open(File.join(dir, ".git/info/exclude"), "a") do |f|
+    f.puts "/.overcommit.yml"
+  end
+
+  # install the overcommit hooks
+  Dir.chdir(dir) do
+    system "overcommit --install"
+    system "overcommit --sign"
+  end
+
+  puts "Installed in #{File.basename(dir)}"
+end
+
+start = ARGV[0] || "."
+
+template = File.read(File.join(__dir__, "overcommit_template.yml.erb"))
+
+# recursively find Git repositories
+Find.find(start) do |path|
+  # a Git repository?
+  next unless File.directory?(File.join(path, ".git"))
+
+  install_overcommit(path, template)
+
+  # stop searching in the subdirectories
+  Find.prune
+end

--- a/git/overcommit/overcommit_template.yml.erb
+++ b/git/overcommit/overcommit_template.yml.erb
@@ -1,0 +1,61 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/sds/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/sds/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/sds/overcommit#configuration
+#
+
+# Check the commit message
+CommitMsg:
+  SpellCheck:
+    enabled: true
+    # force using the English dictionary
+    env:
+      LC_ALL: en_US.UTF-8
+  TextWidth:
+    enabled: true
+    # longer subject (the default is 60)
+    max_subject_width: 80
+    # longer body lines (the default is 72)
+    max_body_width: 100
+
+PreCommit:
+  # do not commit directly to these branches, use Pull Requests!
+  ForbiddenBranches:
+    enabled: true
+    branch_patterns:
+      - master
+      - openSUSE-[0-9]+_[0-9]+
+      - SLE-10
+      - SLE-10-SP[0-9]+
+      - Code-11
+      - Code-11-SP[0-9]+
+      - SLE-[0-9]+-GA
+      - SLE-[0-9]+-SP[0-9]+
+<% if @add_rubocop %>
+  RuboCop:
+    enabled: true
+    # do not pass the RuboCop default parameters to rake, that does not work...
+    flags: []
+    # use a rake task to call the right Rubocop version
+    command: ["rake", "check:rubocop"]
+<% end %>
+<% if @test_command %>
+
+PrePush:
+  RSpec:
+    enabled: true
+    command: <%= @test_command.inspect %>
+    # force English, don't fail because of translations
+    env:
+      LC_ALL: en_US.UTF-8
+<% end %>


### PR DESCRIPTION
## Problem

- It is ugly to see commits like "make Rubocop happy" or "fix failed unit tests". 

## Solution

- I'm using [Overcommit](https://github.com/sds/overcommit) for more than a year and it works fine for me so I'd like to share the solution with others
- It provides an easy way to manage Git hooks so you can automatically run Rubocop after each commit, or run the unit tests on push
- I have implemented a script which can generate the `.overcommit.yml` configuration file for each YaST Git repository
- Another script can import the default YaST dictionary for spell checking the commit messages to avoid false positives

Se more details in the attached `README.md` file.

## Testing

- Tested manually
