### PR TITLE
Added script for removing Leap from GitHub Actions

### DIFF
--- a/github/update_ci/.gitignore
+++ b/github/update_ci/.gitignore
@@ -1,0 +1,5 @@
+.bundle
+.byebug_history
+.vendor
+Gemfile.lock
+node_modules/

--- a/github/update_ci/Gemfile
+++ b/github/update_ci/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gem "byebug"
+gem "netrc"
+gem "octokit"

--- a/github/update_ci/fix_ci.rb
+++ b/github/update_ci/fix_ci.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script updates GitHub Action to only run against Tumbleweed.
+# The SLE/Leap in only supported in the SLE* branches, master is Tumbleweed only.
+#
+# You need admin access rights to temporarily disable the GitHub branch protection
+# and allow direct push to "master".
+#
+
+# install missing gems
+if !File.exist?("./.vendor")
+  puts "Installing the required Rubygems to ./.vendor/bundle ..."
+  system "bundle install --path .vendor/bundle"
+end
+
+# install missing gems
+if !File.exist?("./node_modules")
+  puts "Installing the required NPM packages..."
+  system "npm ci"
+end
+
+require "rubygems"
+require "bundler/setup"
+require "shellwords"
+
+require "octokit"
+require "byebug"
+require_relative "../github_actions/gh_helpers"
+
+# subdirectory where to clone Git repositories
+GIT_CHECKOUT_DIR = "github"
+
+# octokit GitHub client
+github = gh_client
+# all YaST repositories
+git_repos = gh_repos(github, "yast")
+
+# counter
+fixed = 0
+
+git_repos.each do |repo|
+  # where to checkout the Git repository
+  checkout_dir = File.join(GIT_CHECKOUT_DIR, repo.name)
+
+  if !File.directory?(checkout_dir)
+    system("git clone --depth 1 #{repo.ssh_url.shellescape} #{checkout_dir.shellescape}")
+  end
+
+  # process all .yml and .yaml files there
+  Dir[File.join(checkout_dir, ".github/workflows/*.y{a,}ml")].each do |f|
+    # use a Javascript tool because the YAML parser there can keep the comments
+    # in the file
+    system("./remove_leap.js #{f.shellescape}")
+  end
+
+  Dir.chdir(checkout_dir) do
+    # commit and push only if there is a change
+    if !`git diff`.empty?
+      puts "Updating #{repo.name} ..."
+      with_unprotected(github, repo.full_name, repo.default_branch) do
+        system("git commit -a -m \"Fixed CI - build only against Tumbleweed\"")
+        system("git push")
+      end
+
+      fixed += 1
+    end
+  end
+end
+
+puts "Fixed repositories: #{fixed}"

--- a/github/update_ci/package-lock.json
+++ b/github/update_ci/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "update_ci",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "yaml": "^2.3.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    }
+  }
+}

--- a/github/update_ci/package.json
+++ b/github/update_ci/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "yaml": "^2.3.4"
+  }
+}

--- a/github/update_ci/remove_leap.js
+++ b/github/update_ci/remove_leap.js
@@ -1,0 +1,58 @@
+#! /usr/bin/node
+
+// This script removes the "leap_latest" item from the build matrix if it is
+// present. It uses NodeJS because the YAML library can keep the original
+// comments in the file and does not interpret special YAML values like "on".
+//
+// See more details in https://eemeli.org/yaml 
+
+const fs = require("fs");
+const YAML = require("yaml");
+
+const file = process.argv[2];
+if (!file) {
+  console.error("Missing path to the YML file");
+  process.exit(1);
+}
+
+try {
+  const data = fs.readFileSync(file, "utf-8");
+  const doc = YAML.parseDocument(data);
+
+  const jobs = doc.get("jobs");
+  let modified = false;
+
+  if (jobs) {
+    jobs.items.forEach(job => {
+      const distro = job.value?.get("strategy")?.get("matrix")?.get("distro");
+
+      if (distro) {
+        const distroItems = distro.items;
+        // the distro contains only one item, if it is Leap then switch it to
+        // Tumbleweed
+        if (distroItems.length === 1) {
+          if (distroItems[0].value === "leap_latest") {
+            distroItems[0].value = "tumbleweed";
+            modified = true;
+          }
+        } else if (distroItems.length > 1) {
+          // if there are multiple items remove the Leap value from the list
+          // (the other one should be Tumbleweed)
+          if (distroItems.find(d => d.value === "leap_latest")) {
+            distro.items = distroItems.filter(d => d.value !== "leap_latest");
+            modified = true;
+          }
+        }
+      }
+    });
+    
+    if (modified) {
+      fs.writeFileSync(file, doc.toString(), "utf-8");
+      console.log(`File ${file} updated`);
+    }
+  }
+}
+catch (error) {
+  console.error("ERROR: ", error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

- Running CI tests against openSUSE Leap might fail as the `master` branch is for Tumbleweed/ALP only
- [Example Leap failure](https://github.com/yast/yast-storage-ng/actions/runs/6733875258/job/18303524779)

## Solution

- Remove the Leap version from the build matrix
- Example result of run in [yast-storage-ng](https://github.com/yast/yast-storage-ng/commit/50263a98021af17d1538ba63404deec82e110e09) ([without the white space changes](https://github.com/yast/yast-storage-ng/commit/50263a98021af17d1538ba63404deec82e110e09?w=1))

## Notes

- Uses the Javascript YAML parser because it can keep the existing comments in the files
- See https://eemeli.org/yaml
- The script has been already used, all YaST repositories have been updated

